### PR TITLE
Fix compilation of Cosa outside of Arduino IDE

### DIFF
--- a/cores/cosa/Cosa/Types.h
+++ b/cores/cosa/Cosa/Types.h
@@ -140,7 +140,11 @@ union univ32_t {
 /**
  * Workaround for gcc program memory data warning.
  */
-#define __PROGMEM  __attribute__((section(".progmem.data")))
+#ifdef ARDUINO
+	#define __PROGMEM  __attribute__((section(".progmem.data")))
+#elif
+	#define __PROGMEM PROGMEM
+#endif
 
 #undef PSTR
 /**


### PR DESCRIPTION
I have been able to identify this issue compiling Cosa outside of the Arduino IDE on both Mac (10.9.1) with avr-gcc (4.8.2/4.7.2) and Ubuntu (13.10) with avr-gcc (4.7.2). Conditionally defining __PROGMEM in Types.hh fixes the issue for both platforms without affecting Arduino (1.0.5) 
