### PR TITLE
__ARDUINO_MEGA__ PinChangeInterrupt broken

### DIFF
--- a/cores/cosa/Cosa/PinChangeInterrupt.cpp
+++ b/cores/cosa/Cosa/PinChangeInterrupt.cpp
@@ -36,7 +36,7 @@ PinChangeInterrupt::enable()
 #if !defined(__ARDUINO_MEGA__)
     pin[m_pin] = this;
 #else
-    uint8_t ix = m_pin - (m_pin < 24 ? 24 : 48);
+    uint8_t ix = m_pin - (m_pin < 24 ? 16 : 48);
     pin[ix] = this;
 #endif
   }
@@ -50,7 +50,7 @@ PinChangeInterrupt::disable()
 #if !defined(__ARDUINO_MEGA__)
     pin[m_pin] = 0;
 #else
-    uint8_t ix = m_pin - (m_pin < 24 ? 24 : 48);
+    uint8_t ix = m_pin - (m_pin < 24 ? 16 : 48);
     pin[ix] = 0;
 #endif
   }


### PR DESCRIPTION
The offset into the 'pin' instance array, ix, incorrectly mapped PCINT0 pins [16..23] onto pin[-8..-1].  Correct mapping is [16..23] onto pin[0..7].
