### PR TITLE
PinChangeInterrupt refactor

### DIFF
--- a/cores/cosa/Cosa/PinChangeInterrupt.cpp
+++ b/cores/cosa/Cosa/PinChangeInterrupt.cpp
@@ -34,7 +34,7 @@ PinChangeInterrupt::enable()
   synchronized {
     *PCIMR() |= m_mask;
 #if defined(__ARDUINO_MEGA__)
-    uint8_t ix = m_pin - (m_pin < 24 ? 16 : 48);
+    uint8_t ix   = m_pin - (m_pin < 24 ? 16 : 48);
     instance[ix] = this;
 #else
     instance[m_pin] = this;
@@ -48,7 +48,7 @@ PinChangeInterrupt::disable()
   synchronized {
     *PCIMR() &= ~m_mask;
 #if defined(__ARDUINO_MEGA__)
-    uint8_t ix = m_pin - (m_pin < 24 ? 16 : 48);
+    uint8_t ix   = m_pin - (m_pin < 24 ? 16 : 48);
     instance[ix] = 0;
 #else
     instance[m_pin] = 0;
@@ -67,6 +67,7 @@ PinChangeInterrupt::begin()
   for (uint8_t i = 0; i < Board::PCINT_MAX; i++)
     state[i] = *Pin::PIN(i << 3);
 #endif
+
   synchronized {
 #if defined(__ARDUINO_TINYX5__)
     bit_set(GIMSK, PCIE);
@@ -100,186 +101,125 @@ PinChangeInterrupt::end()
   }
 }
 
+void
+PinChangeInterrupt::on_interrupt( uint8_t pcint, uint8_t mask, uint8_t base_pin )
+{
+  uint8_t newState      = *Pin::PIN(base_pin);
+  uint8_t changed       = (newState ^ state[pcint]) & mask;
+  uint8_t base_instance = pcint << 3;
+
+  for (uint8_t i = 0; changed && (i < CHARBITS); i++) {
+    if ((changed & 1) && (instance[base_instance + i] != NULL)) {
+      instance[base_instance + i]->on_interrupt();
+    }
+    changed >>= 1;
+  }
+
+  state[pcint] = newState;
+}
+
 #if defined(__ARDUINO_TINYX5__)
 
 ISR(PCINT0_vect)
 {
-  uint8_t mask = PCMSK0;
-  uint8_t state = *Pin::PIN(0);
-  uint8_t changed = (state ^ PinChangeInterrupt::state[0]) & mask;
-  for (uint8_t i = 0; i < CHARBITS; i++) {
-    if ((changed & 1) && (PinChangeInterrupt::instance[i] != NULL)) {
-      PinChangeInterrupt::instance[i]->on_interrupt();
-    }
-    changed >>= 1;
-  }
-  PinChangeInterrupt::state[0] = state;
+  PinChangeInterrupt::on_interrupt( 0, PCMSK0, 0 );
 }
 
 #elif defined(__ARDUINO_TINYX4__)
 
-void
-PinChangeInterrupt::on_interrupt(uint8_t ix, uint8_t mask)
-{
-  uint8_t px = (ix << 3);
-  uint8_t state = *Pin::PIN(px);
-  uint8_t changed = (state ^ PinChangeInterrupt::state[ix]) & mask;
-  for (uint8_t i = 0; i < CHARBITS; i++) {
-    if ((changed & 1) && (PinChangeInterrupt::instance[i + px] != NULL)) {
-      PinChangeInterrupt::instance[i + px]->on_interrupt();
-    }
-    changed >>= 1;
-  }
-  PinChangeInterrupt::state[ix] = state;
-}
-
 ISR(PCINT0_vect)
 {
-  PinChangeInterrupt::on_interrupt(0, PCMSK0);
+  PinChangeInterrupt::on_interrupt(0, PCMSK0, 0);
 }
 
 ISR(PCINT1_vect)
 {
-  PinChangeInterrupt::on_interrupt(1, PCMSK1);
+  PinChangeInterrupt::on_interrupt(1, PCMSK1, 8);
 }
 
 #elif defined(__ARDUINO_TINYX61__)
 
 ISR(PCINT0_vect)
 {
-  uint8_t changed;
-  uint8_t state;
   uint8_t mask;
+  uint8_t ix;
+
   if (GIFR & _BV(INTF0)) {
     mask = PCMSK0;
-    state = *Pin::PIN(0);
-    changed = (state ^ PinChangeInterrupt::state[0]) & mask;
-  }
-  else {
+    ix   = 0;
+  } else {
     mask = PCMSK1;
-    state = *Pin::PIN(8);
-    changed = (state ^ PinChangeInterrupt::state[1]) & mask;
+    ix   = 1;
   }
-  for (uint8_t i = 0; i < CHARBITS; i++) {
-    if ((changed & 1) && (PinChangeInterrupt::instance[i] != NULL)) {
-      PinChangeInterrupt::instance[i]->on_interrupt();
-    }
-    changed >>= 1;
-  }
-  PinChangeInterrupt::state[0] = state;
+  PinChangeInterrupt::on_interrupt( ix, mask, (ix << 3) );
 }
 
 #elif defined(__ARDUINO_STANDARD__)
 
-void
-PinChangeInterrupt::on_interrupt(uint8_t ix, uint8_t mask)
-{
-  uint8_t px = (ix << 3) - (ix < 2 ? 0 : 2);
-  uint8_t state = *Pin::PIN(px);
-  uint8_t changed = (state ^ PinChangeInterrupt::state[ix]) & mask;
-  for (uint8_t i = 0; i < CHARBITS; i++) {
-    if ((changed & 1) && (PinChangeInterrupt::instance[i + px] != NULL)) {
-      PinChangeInterrupt::instance[i + px]->on_interrupt();
-    }
-    changed >>= 1;
-  }
-  PinChangeInterrupt::state[ix] = state;
-}
-
 ISR(PCINT0_vect)
 {
-  PinChangeInterrupt::on_interrupt(1, PCMSK0);
+  PinChangeInterrupt::on_interrupt(1, PCMSK0, 8); // only 8..13 are available
 }
 
 ISR(PCINT1_vect)
 {
-  PinChangeInterrupt::on_interrupt(2, PCMSK1);
+  PinChangeInterrupt::on_interrupt(2, PCMSK1, 14); // instance[22..23] not used
 }
 
 ISR(PCINT2_vect)
 {
-  PinChangeInterrupt::on_interrupt(0, PCMSK2);
+  PinChangeInterrupt::on_interrupt(0, PCMSK2, 0);
 }
 
 #elif defined(__ARDUINO_STANDARD_USB__)
 
 ISR(PCINT0_vect)
 {
-  uint8_t mask = PCMSK0;
-  uint8_t state = *Pin::PIN(0);
-  uint8_t changed = (state ^ PinChangeInterrupt::state[0]) & mask;
-  for (uint8_t i = 0; i < CHARBITS; i++) {
-    if ((changed & 1) && (PinChangeInterrupt::instance[i] != NULL)) {
-      PinChangeInterrupt::instance[i]->on_interrupt();
-    }
-    changed >>= 1;
-  }
-  PinChangeInterrupt::state[0] = state;
+  PinChangeInterrupt::on_interrupt(0, PCMSK0, 0);
 }
 
 #elif defined(__ARDUINO_MEGA__)
 
-void
-PinChangeInterrupt::on_interrupt(uint8_t ix, uint8_t mask)
-{
-  uint8_t px = (ix << 3);
-  uint8_t rx = (ix == 0 ? 16 : 64);
-  uint8_t state = *Pin::PIN(rx);
-  uint8_t changed = (state ^ PinChangeInterrupt::state[ix]) & mask;
-  for (uint8_t i = 0; i < CHARBITS; i++) {
-    if ((changed & 1) && (PinChangeInterrupt::instance[i + px] != NULL)) {
-      PinChangeInterrupt::instance[i + px]->on_interrupt();
-    }
-    changed >>= 1;
-  }
-  PinChangeInterrupt::state[ix] = state;
-}
-
 ISR(PCINT0_vect)
 {
-  PinChangeInterrupt::on_interrupt(0, PCMSK0);
+  PinChangeInterrupt::on_interrupt(0, PCMSK0, 16);
 }
+
+/*
+  Although not implemented, these PCINTs are actually available:
+    PCINT8  is PE0 (RXD0) aka RX0 aka D0
+    PCINT9  is PJ0 (RXD3) aka D15
+    PCINT10 is PJ1 (TXD3) aka D14
+    (PCINT11..15 are not available)
+
+  Because of the non-sequential pins, handling would be quite different
+*/
 
 ISR(PCINT1_vect)
 {
-  PinChangeInterrupt::on_interrupt(1, PCMSK1);
+//  PinChangeInterrupt::on_interrupt(1, PCMSK1, ??);
 }
 
 ISR(PCINT2_vect)
 {
-  PinChangeInterrupt::on_interrupt(2, PCMSK2);
+  PinChangeInterrupt::on_interrupt(2, PCMSK2, 64);
 }
 
 #elif defined(__ARDUINO_MIGHTY__)
 
-void
-PinChangeInterrupt::on_interrupt(uint8_t ix, uint8_t mask)
-{
-  uint8_t px = (ix << 3);
-  uint8_t state = *Pin::PIN(px);
-  uint8_t changed = (state ^ PinChangeInterrupt::state[ix]) & mask;
-  for (uint8_t i = 0; i < CHARBITS; i++) {
-    if ((changed & 1) && (PinChangeInterrupt::instance[i + px] != NULL)) {
-      PinChangeInterrupt::instance[i + px]->on_interrupt();
-    }
-    changed >>= 1;
-  }
-  PinChangeInterrupt::state[ix] = state;
-}
-
 ISR(PCINT0_vect)
 {
-  PinChangeInterrupt::on_interrupt(0, PCMSK0);
+  PinChangeInterrupt::on_interrupt(0, PCMSK0, 0);
 }
 
 ISR(PCINT1_vect)
 {
-  PinChangeInterrupt::on_interrupt(1, PCMSK1);
+  PinChangeInterrupt::on_interrupt(1, PCMSK1, 8);
 }
 
 ISR(PCINT2_vect)
 {
-  PinChangeInterrupt::on_interrupt(2, PCMSK2);
+  PinChangeInterrupt::on_interrupt(2, PCMSK2, 16);
 }
 
 ISR(PCINT3_vect)

--- a/cores/cosa/Cosa/PinChangeInterrupt.hh
+++ b/cores/cosa/Cosa/PinChangeInterrupt.hh
@@ -48,15 +48,16 @@ private:
   friend void PCINT3_vect(void);
 #endif
 #endif
+#endif
   /**
    * Map interrupt source: Check which pin(s) are the source of the
    * pin change interrupt and call the corresponding interrupt handler
    * per pin.
    * @param[in] ix port index.
    * @param[in] mask pin mask.
+   * @param[in] base pin number from IDE.
    */
-  static void on_interrupt(uint8_t ix, uint8_t mask);
-#endif
+  static void on_interrupt(uint8_t ix, uint8_t mask, uint8_t base_pin );
 
 public:
   /**


### PR DESCRIPTION
This saved almost 100 bytes RAM (on the MEGA), eliminated 60 LOC, and (probably) decreased the amount of time spent in the ISRs.  It should also be easier to add other processor types.

NB: Although I tried to break it up into several smaller commits, there were two additional parts to the last commit that were not mentioned in that comment:
1. Removed the extraneous `PinChangeInterrupt::` from inside static member `on_interrupt`.  Also changed <i>local</i> `state` to `newState` to disambiguate it from <i>member</i> `state` and make its purpose more obvious.
2. Added short circuit `changed` test to the for loop.  The short circuit will, on average, eliminate 4 for-loop iterations for the price of an extra zero test.  Also, if the input has already changed a <i>second</i> time, the short circuit will eliminate all 8 iterations.  This is common with a bouncy input.

Tested on Mega and ProMini.
