### PR TITLE
Implement general-purpose microsecond timer

### DIFF
--- a/cores/cosa/Cosa/RTC.hh
+++ b/cores/cosa/Cosa/RTC.hh
@@ -57,6 +57,7 @@ public:
     uint32_t expiration;
 
     virtual void start();
+    virtual void stop();
 
     virtual void on_interrupt() = 0;
   };


### PR DESCRIPTION
In trying to implement a fully event-driven system, I came across a few cases where I needed to wait for a short period of time - shorter than the shortest `Watchdog` interval.  And, as you have probably experienced, starting multiple timed processes can be awkward to coordinate with `sleep` intervals. Rather than spin on `RTC::micros()`, I implemented a nested `Timer` class in `RTC`.  It leverages the TIMER0_OVF interrupt and then uses OCR0A for increased (sub-tick) resolution.  For the full description, see the comment on my commit.  I think this may implement your Issue #67.
