### PR TITLE
RTC::Timer fixes, example program

### DIFF
--- a/cores/cosa/Cosa/RTC.cpp
+++ b/cores/cosa/Cosa/RTC.cpp
@@ -80,6 +80,12 @@ RTC::us_per_tick()
   return (US_PER_TICK);
 }
 
+uint16_t
+RTC::us_per_timer_cycle()
+{
+  return (US_PER_TIMER_CYCLE);
+}
+
 uint32_t
 RTC::micros()
 {
@@ -89,7 +95,7 @@ RTC::micros()
   synchronized {
     res = s_uticks;
     cnt = TCNT0;
-    if ((TIFR0 & _BV(TOV0)) && cnt < COUNT) res += US_PER_TICK;
+    if (TIFR0 & _BV(TOV0)) res += US_PER_TICK;
   }
   // Convert ticks to micro-seconds
   res += ((uint32_t) cnt) * US_PER_TIMER_CYCLE;
@@ -118,6 +124,8 @@ ISR(TIMER0_OVF_vect)
   RTC::s_uticks += US_PER_TICK;
   
   if (RTC::Timer::s_queue_ticks > 0) {
+    if (RTC::Timer::MEASURE)
+      RTC::Timer::enter_ISR_cycle = TCNT0;
     // Decrement the most significant part of the RTC::Timer that's
     // expiring first. 
     RTC::Timer::s_queue_ticks--;
@@ -125,6 +133,7 @@ ISR(TIMER0_OVF_vect)
       if (TCNT0 >= OCR0A) {
         // TCNT0 is already past the requested OCR0A time. Interrupt
         // disabling must have kept us from getting here in time. 
+        TIFR0 |= _BV(TOV0); // RTC::micros() doesn't need to add US_PER_TICK any more
         RTC::Timer::schedule();
       } else {
         // The remaining time will be caught by OCR0A. Clear the
@@ -138,17 +147,59 @@ ISR(TIMER0_OVF_vect)
 
 // Timer queue and state
 Head RTC::Timer::s_queue;
-volatile uint8_t RTC::Timer::s_queue_ticks = 0;
+volatile uint32_t RTC::Timer::s_queue_ticks = 0;
 volatile bool RTC::Timer::s_running = false;
+
+#ifdef RTC_TIMER_MEASURE
+
+uint8_t RTC::Timer::enter_setup_cycle        = 0;
+uint8_t RTC::Timer::exit_setup_cycle         = 0;
+uint8_t RTC::Timer::enter_start_cycle        = 0;
+uint8_t RTC::Timer::enter_schedule_cycle     = 0;
+uint8_t RTC::Timer::enter_ISR_cycle          = 0;
+uint8_t RTC::Timer::enter_on_interrupt_cycle = 0;
+
+#endif
+
+/**
+ * Measured timings, deduced from Timer0 cycles with 16MHz MCU clock*
+ *
+ * After making any code changes in RTC or RTC::Timer, you may want to re-measure
+ * the times for various RTC::Timer operations by using a test program such as
+ * CosaBenchmarkRTCTimer.ino.  The procedure is as follows:
+ * (1) Reduce all xxx_US constants to 16 instructions.
+ * (2) Rebuild and run a test program to obtain new values.
+ * (3) Rebuild and verify that actual times are 0-2 timer cycles *greater*
+ *     than the expiration times.  The actual time includes returning from 
+ *     the interrupt and calling RTC::micros() for the stop time, so the
+ *     actual time should always report taking a little longer than requested.
+ */
+
+/** Number of instructions from ::start to ::setup (queued dispatch) */
+static const int32_t START_US = (320 / I_CPU);
+
+/** Number of instructions from the beginning of ::setup to the end of ::setup */
+static const int32_t SETUP_US = (128 / I_CPU);
+  
+/** Number of instructions from ISR to on_interrupt */
+static const int32_t DISPATCH_US = ((272+64) / I_CPU);
+  // added 1 cycle for int vectoring because TCNT0 is always OCR0A+1 at start of ISR
+
+/** Visible constant computed from hidden constants */
+const uint32_t
+RTC::Timer::QUEUED_DISPATCH_TIME = (START_US + SETUP_US + DISPATCH_US);
 
 void
 RTC::Timer::setup(uint32_t us)
 {
+  if (MEASURE)
+    enter_setup_cycle=TCNT0;
+
   uint32_t timer_cycles  = us / US_PER_TIMER_CYCLE;
   if (timer_cycles >= 256) {
     timer_cycles += TCNT0;
-    OCR0A = (uint8_t) timer_cycles;
     TIMSK0 &= ~_BV(OCIE0A);
+    OCR0A = (uint8_t) timer_cycles;
     TIFR0 |=  _BV(OCF0A);
     s_queue_ticks = timer_cycles >> 8;
     return;
@@ -179,6 +230,9 @@ RTC::Timer::setup(uint32_t us)
     TIMSK0 |= _BV(OCIE0A);
     s_queue_ticks = 0;
   }
+
+  if (MEASURE)
+    exit_setup_cycle = TCNT0;
 }
 
 void
@@ -187,12 +241,15 @@ RTC::Timer::start()
   // Check if already queued
   if (is_started()) return;
 
+  if (MEASURE)
+    enter_start_cycle = TCNT0;
+
   // Not started yet. If this timer is getting *reStarted*, and we
   // are still within the ISR context, stack overflow would be
   // happening soon. Instead, put it in `s_queue` for later, even
   // though it might happen a little later than requested.
   int32_t us = m_expires - RTC::micros();
-  bool immediate = (us <= US_PER_TIMER_CYCLE);
+  bool immediate = (us <= (int32_t)QUEUED_DISPATCH_TIME);
   if (immediate) {
     us = 0;
     if (s_running)
@@ -200,21 +257,24 @@ RTC::Timer::start()
   }
   if (!immediate) {
     bool first_changed = true;
-    m_expires = RTC::micros() + us;
     synchronized {
       Linkage* succ = &s_queue;
       Linkage* timer;
       while ((timer = succ->get_pred()) != &s_queue) {
-	if (((RTC::Timer*) timer)->m_expires <= m_expires) {
-	  first_changed = false;
-	  break;
-	}
-	succ = timer;
+        if (((RTC::Timer*) timer)->m_expires <= m_expires) {
+          first_changed = false;
+          break;
+        }
+        succ = timer;
       }
       succ->attach(this);
       if (first_changed) {
-	us = m_expires - RTC::micros();
-	setup(us);
+        us = m_expires - RTC::micros();
+        if (us >= (SETUP_US + DISPATCH_US))
+          us -= DISPATCH_US;
+        else
+          us = 0;
+        setup(us);
       }
     }
   } 
@@ -241,11 +301,15 @@ RTC::Timer::stop()
 void
 RTC::Timer::schedule()
 {
+  if (MEASURE)
+    enter_schedule_cycle = TCNT0;
+
   s_running = true;
   Linkage* timer;
   while ((timer = s_queue.get_succ()) != &s_queue) {
     int32_t us = ((RTC::Timer*) timer)->m_expires - RTC::micros();
-    if (us > US_PER_TIMER_CYCLE) {
+    if (us >= (SETUP_US + DISPATCH_US)) {
+      us -= DISPATCH_US;
       setup(us);
       break;
     }
@@ -257,6 +321,9 @@ RTC::Timer::schedule()
 
 ISR(TIMER0_COMPA_vect)
 {
+  if (RTC::Timer::MEASURE)
+    RTC::Timer::enter_ISR_cycle = TCNT0;
+
   TIMSK0 &= ~_BV(OCIE0A);
   RTC::Timer::schedule();
 }

--- a/cores/cosa/Cosa/RTCMeasure.cpp
+++ b/cores/cosa/Cosa/RTCMeasure.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file Cosa/RTCMeasure.cpp
+ * @version 1.0
+ *
+ * @section License
+ * Copyright (C) 2012-2013, Mikael Patel
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA  02111-1307  USA
+ *
+ * This file is part of the Arduino Che Cosa project.
+ */
+
+#include "Cosa/RTCMeasure.hh"
+
+#ifdef RTC_TIMER_MEASURE
+
+uint8_t RTCMeasure::start_immediate_cycles = 0;
+uint8_t RTCMeasure::start_queued_cycles    = 0;
+uint8_t RTCMeasure::setup_cycles           = 0;
+uint8_t RTCMeasure::dispatch_cycles        = 0;
+
+const uint16_t RTCMeasure::I_PER_CYCLE = (RTC::us_per_timer_cycle() * I_CPU);
+
+void
+RTCMeasure::start()
+{
+  m_dispatched = false;
+
+  enter_setup_cycle        = 0;
+  exit_setup_cycle         = 0;
+  enter_start_cycle        = 0;
+  enter_schedule_cycle     = 0;
+  enter_ISR_cycle          = 0;
+  enter_on_interrupt_cycle = 0;
+
+  start_immediate_cycles = 0;
+  start_queued_cycles    = 0;
+  setup_cycles           = 0;
+  dispatch_cycles        = 0;
+  
+  RTC::Timer::start();
+
+  if ((enter_on_interrupt_cycle != 0) ||
+      ((enter_setup_cycle == 0) && (exit_setup_cycle == 0)))
+    // It was an immediate dispatch
+    start_immediate_cycles = enter_on_interrupt_cycle - enter_start_cycle + 1;
+  else {
+    // It was queued up and dispatched by an interrupt
+    start_queued_cycles = enter_setup_cycle - enter_start_cycle + 1;
+    setup_cycles        = exit_setup_cycle  - enter_setup_cycle + 1;
+  }
+}
+
+void
+RTCMeasure::on_expired()
+{
+  enter_on_interrupt_cycle = TCNT0;
+
+  dispatch_cycles = enter_on_interrupt_cycle - enter_ISR_cycle + 1;
+  
+  m_dispatched = true;
+}
+
+#endif

--- a/cores/cosa/Cosa/RTCMeasure.hh
+++ b/cores/cosa/Cosa/RTCMeasure.hh
@@ -1,0 +1,58 @@
+/**
+ * @file Cosa/RTCMeasure.hh
+ * @version 1.0
+ *
+ * @section License
+ * Copyright (C) 2012-2013, Mikael Patel
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA  02111-1307  USA
+ *
+ * This file is part of the Arduino Che Cosa project.
+ */
+
+#ifndef __COSA_RTCMeasure_HH__
+#define __COSA_RTCMeasure_HH__
+
+#include "Cosa/RTC.hh"
+
+#ifdef RTC_TIMER_MEASURE
+
+/**
+ * This class is used to gather performance timings of the RTC::Timer class.
+ *   See also RTC.CPP and CosaBenchmarkRTCTimer.ino
+ */
+class RTCMeasure : public RTC::Timer
+{
+  volatile bool m_dispatched;
+public:
+  RTCMeasure() : Timer(), m_dispatched(false) {};
+  
+  bool is_dispatched() const { return m_dispatched; }
+  
+  virtual void start();
+  virtual void on_expired();
+
+  static uint8_t start_immediate_cycles;
+  static uint8_t start_queued_cycles;
+  static uint8_t setup_cycles;
+  static uint8_t dispatch_cycles;
+  
+  static const uint16_t I_PER_CYCLE;
+};
+
+#endif
+
+#endif

--- a/examples/Benchmarks/CosaBenchmarkRTCTimer/CosaBenchmarkRTCTimer.ino
+++ b/examples/Benchmarks/CosaBenchmarkRTCTimer/CosaBenchmarkRTCTimer.ino
@@ -1,0 +1,255 @@
+/**
+ * @file CosaBenchmarkRTC.ino
+ * @version 1.0
+ *
+ * @section License
+ * Copyright (C) 2012-2013, Mikael Patel
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA  02111-1307  USA
+ *
+ * @section Description
+ * Cosa RTC (Real-Time Clock) Benchmark. Validate and measurements.
+ *
+ * @section Circuit
+ * This example requires no special circuit. Uses serial output.
+ *
+ * This file is part of the Arduino Che Cosa project.
+ */
+
+#include "Cosa/RTC.hh"
+#include "Cosa/RTCMeasure.hh"
+#include "Cosa/Memory.h"
+#include "Cosa/Trace.hh"
+#include "Cosa/IOStream/Driver/UART.hh"
+
+static const Board::DigitalPin TEST_PIN = Board::D7;
+
+class Simple : public RTC::Timer
+{
+public:
+  volatile static bool flag;
+
+  virtual void on_expired() { flag = !flag; }
+};
+volatile bool Simple::flag = false;
+
+class OneShot : public Simple
+{
+public:
+  volatile static uint32_t time_stamp;
+
+  virtual void on_expired()
+    {
+      time_stamp = RTC::micros();
+      flag = !flag;
+//      OutputPin::write( TEST_PIN, !Pin::read( TEST_PIN ) );
+    }
+};
+volatile uint32_t OneShot::time_stamp;
+
+class TimerGroup : public RTC::Timer
+{
+public:
+  volatile static uint8_t started;
+
+  virtual void start() { started++; RTC::Timer::start(); }
+  
+  virtual void on_expired()
+    {
+      started--;
+    }
+};
+
+volatile uint8_t TimerGroup::started = 0;
+
+static Simple  timer;
+static OneShot one_shot;
+
+void setup()
+{
+  uint32_t start, stop, expected, actual;
+  bool     err = false;
+
+  // Start the trace output stream on the serial port
+  uart.begin(9600);
+  trace.begin(&uart, PSTR("CosaBenchmarkRTCTimer: started"));
+
+  // Check amount of free memory
+  TRACE(free_memory());
+  TRACE(sizeof(RTC::Timer));
+  TRACE(sizeof(Simple));
+  TRACE(sizeof(OneShot));
+  
+  // Print CPU clock and instructions per 1MHZ 
+  TRACE(F_CPU);
+  TRACE(I_CPU);
+
+  RTC::begin();
+
+  // Check timer parameters
+  uint32_t us_per_tick = RTC::us_per_tick();
+  TRACE(us_per_tick);
+  TRACE(RTC::seconds());
+
+#ifdef RTC_TIMER_MEASURE
+  // Measure basic performance
+  RTCMeasure test;
+  
+  uint32_t max_immediate_expiration = 0;
+  uint32_t sum_immediate = 0;
+  uint32_t s;
+  uint32_t us_per_timer_cycle = RTC::us_per_timer_cycle();
+  
+  for (s = 0; s < 1024; s++) {
+    test.expire_after( s );
+    test.start();
+    while (!test.is_dispatched())
+      ;
+    if (RTCMeasure::start_queued_cycles > 0)
+      break;
+    sum_immediate += RTCMeasure::start_immediate_cycles;
+  }
+  uint32_t avg_immediate = (sum_immediate * us_per_timer_cycle) / s;
+  max_immediate_expiration = s;
+  trace.printf_P( PSTR("Expirations < %l us will be immediately dispatched\n"
+                  "  Avg immediate dispatch = %l us (%l instructions)\n"),
+                  max_immediate_expiration, avg_immediate, avg_immediate*I_CPU );
+  uart.flush();
+
+  uint32_t sum_start    = 0;
+  uint32_t sum_setup    = 0;
+  uint32_t sum_dispatch = 0;
+  
+  for (; s<1024; s++) {
+    test.expire_after( s );
+    test.start();
+    while (!test.is_dispatched())
+      ;
+    sum_start    += (uint32_t) RTCMeasure::start_queued_cycles;
+    sum_setup    += (uint32_t) RTCMeasure::setup_cycles;
+    sum_dispatch += (uint32_t) RTCMeasure::dispatch_cycles;
+  }
+  uint32_t queued_samples = s - max_immediate_expiration;
+  
+  uint32_t avg_start    = ((sum_start    * us_per_timer_cycle) / queued_samples);
+  uint32_t avg_setup    = ((sum_setup    * us_per_timer_cycle) / queued_samples);
+  uint32_t avg_dispatch = ((sum_dispatch * us_per_timer_cycle) / queued_samples);
+  
+  trace.printf_P( PSTR("For queued expirations,\n"
+                  "  Avg start    = %l us (%l instructions)\n"
+                  "  Avg setup    = %l us (%l instructions)\n"
+                  "  Avg dispatch = %l us (%l instructions)\n"),
+                  avg_start   , avg_start    * I_CPU,
+                  avg_setup   , avg_setup    * I_CPU,
+                  avg_dispatch, avg_dispatch * I_CPU );
+  uart.flush();
+#endif
+
+  // microsecond test
+  for (expected=0; expected<=2048;) {
+    Simple::flag = false;
+    start        = RTC::micros();
+    one_shot.expire_at( start + expected );
+    one_shot.start();
+    while (Simple::flag == false)
+      ;
+    actual = OneShot::time_stamp - start;
+    trace.printf_P( PSTR("expire_after( %ul us): actual %l us\n"), expected, actual );
+    uart.flush();
+    if (expected < 100)
+      expected += 7;
+    else if (expected < 256)
+      expected += 13;
+    else
+      expected += 41;
+  }
+  
+  // tick test
+  Simple::flag = false;
+  expected = us_per_tick;
+  start = RTC::micros();
+  one_shot.expire_at( start + expected );
+  one_shot.start();
+  while (Simple::flag == false)
+    ;
+  actual = OneShot::time_stamp - start;
+  trace.printf_P( PSTR("expire_after(%ul us): actual %ul us\n"), expected, actual );
+  uart.flush();
+
+  //  1000x tick tests
+  Simple::flag = false;
+  expected = 0;
+  start = RTC::micros();
+  timer.expire_at( start );
+  for (uint16_t i=0; i<1000; i++) {
+    expected += us_per_tick;
+    // Make sure the expirations are evenly spaced, even
+    //    if one expires a little late or early.  The
+    //    next one will aim for the correct expiration.
+    timer.expire_at( timer.expire_at() + us_per_tick );
+    timer.start();
+    while (Simple::flag == (i&1))
+      ;
+    stop = RTC::micros();
+  }
+  actual = stop - start;
+  trace.printf_P( PSTR("1000X expire_at( n * %ul us): expected %ul, actual %ul us\n"),
+                  us_per_tick, expected, actual);
+  uart.flush();
+
+  TimerGroup bunch[50];
+  const uint32_t base_offset = 500000;
+  const uint32_t increment   = 100000;
+  expected = base_offset + (membersof(bunch)-1)*increment;
+
+  start = RTC::micros();
+  for (uint32_t i=0; i < membersof(bunch); i++)
+    bunch[i].expire_at( start + base_offset + i*increment );
+  uint32_t startStart = RTC::micros();
+  for (int8_t i=membersof(bunch)-1; i >= 0; i--) {
+    bunch[i].start();
+  }
+  trace.printf_P( PSTR("%d timers started in %ulus\n"), 
+                  membersof(bunch), RTC::micros()-startStart );
+
+  uint32_t timeout = ((expected / 1000000) + 2) * 1000000;
+  while (TimerGroup::started > 0) {
+    stop = RTC::micros();
+    if (stop-start > timeout) {
+      trace.printf_P( PSTR("ERROR: %d timers still running\n"), TimerGroup::started );
+      trace.printf_P( PSTR("  started at %ul, now=%ul, expiring at "), start, stop );
+      for (uint8_t i=0; i < membersof(bunch); i++) {
+        trace << bunch[i].expire_at() << PSTR(", ");
+        bunch[i].stop();
+      }
+      trace << endl;
+      err = true;
+      break;
+    }
+  }
+  stop = RTC::micros();
+  actual = stop-start;
+  
+  uint32_t expected_ms = expected / 1000;
+  trace.printf_P( PSTR("elapsed time (0.5 + %d*0.1s = %ul.%uls ): actual %ulus\n"),
+            (membersof(bunch)-1), (expected_ms/1000), (expected_ms % 1000), actual );
+  uart.flush();
+}
+
+void loop()
+{
+  ASSERT(true == false);
+}


### PR DESCRIPTION
Well, this isn't the pull request I expected... Here's what I did:
        1. shell `git fetch upstream`
        2. shell `git merge upstream/master`
        3. github for Windows synch on my repo (I did not expect to have to do this)
        4. edit files
        5. gfW commit to my repo
        6. pull request
However, it seems like the diff is from your last pull, even though I started with your "Rectoring..." 5690e1fbec1db8dee81e1ff587797260eff3bae3.  These steps are what I did last time... should I be doing something else?  The first time, I made a branch of my repo, and the pull request was for the branch.  After the pull request was accepted, the branch was deleted.  Sigh.  I'm thinking maybe gfW is too simplistic.  Or I am.

Also apologies if RTCMeasure.\* are in the wrong directory.  They compile to nothing if the define is off, so it doesn't hurt.  Because it's coupled to RTC::Timer (as a friend class), I put it there for now.  As fairly pure instrumentation code, maybe it should go elsewhere?

There is another question at RTC.cpp line 98.

Thanks!
