### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,160 +1,30 @@
 Che Cosa?
-=========
-
+---------
 
 Cosa is an object-oriented platform for Arduino. It replaces the Arduino
 and Wiring library with a large set of integrated classes that support 
 the full range of AVR/ATmega/ATtiny internal hardware modules; all pin
 modes, Digital, and Analog Pins, External and Pin Change Interrupts,
 Analog Comparator, PWM, Watchdog, Timer0 (RTC), Timer1 (Servo), UART, USI,
-SPI, TWI and EEPROM.   
+SPI, TWI and EEPROM.
 
-Cosa is implemented as an Arduino IDE core. The Cosa platform can be
-used with almost all Arduino boards and ATtiny/ATmega processors. All
-classes may be compiled for all variants.
+More informations are available in the [documentation](./documentation)
 
-Though object-oriented with optional operator overloading syntax,
-Cosa is between 2-10X faster than Arduino with regard to digital pin
-functions. This comes with a small price-tag; memory, 4 bytes per
-digital pin and 12 bytes per analog pin. Cosa analog pin objects
-holds the latest sample and allows an event handler. See the
-benchmarks in the examples directory for further details.
+Cosa API
+--------
 
-Cosa contains several data streaming formats for message passing and
-data streaming. Google Protocol Buffers are supported together with a
-data streaming format (Ciao) for encoding of C/C++ language data types
-such as strings, integer and floating pointer numbers into a binary
-format. It may be used for a number of applications; tracing, remote
-procedure calls, data exchange between Arduino devices, etc. The
-format allows user data types to be defined and values exchanged
-without additional encoding. The stream header itself is a pre-defined
-serializable data type. Ciao is used to define an Arduino monitoring
-and control language (Cosa fai) which has much in common with
-Firmata. 
+The API documentation is available :
 
-The primary programming paradigm is object-oriented and
-state-machine/event driven with proto-threads or multi-tasking. There
-is a large number of device drivers available for SPI, I2C (TWI) and
-1-Wire (OWI). A strict directory structure is used to organize the
-Cosa/driver source code. Sub-directories are used for each driver
-type. This allows a foundation for scaling and configuration.
+* [online](http://dl.dropbox.com/u/993383/Cosa/doc/html/index.html)
+* Compressed for [download](http://dl.dropbox.com/u/993383/Cosa/doc.zip).
 
-Cosa uses the Arduino IDE and build system. Cosa classes are included
-with prefix, e.g. "Cosa/FileName.hh". It is possible to use both
-Arduino and Cosa functions together, though in some cases the Cosa
-objects may become inconsistent. 
-
-To improve debugging and testing there is assert/trace/syslog style
-support. The IOStream class allows output to both serial wire/wireless
-communication (UART/VWIO) and small TFT displays (such as the ST7735,
-ST7565, HD44780, and PCD8544). The Cosa LCD class extends
-IOStream::Device with additional common LCD functions. The Cosa LCD
-Menu class adds a simple framework for creating menu systems with
-program state such as integer ranges, bitsets and enumeration
-variables. All menu data structures are stored in program memory and
-the SRAM requirement is minimum. A macro set hides the details of
-creating the data structures in program memory.
-
-The drawing Canvas class supports basic drawing operation
-and scripting to reduce program memory footprint. The Canvas class
-also supports drawing of icons and multiple fonts (GLCD and UTFT). 
-
-The popular VirtualWire library has been refactored to the
-object-oriented style of Cosa (VWI) and extended with three additional
-codecs; Manchester, 4B5B and Bitstuffing. This allows basic ultra
-cheap wireless nodes with RF315/433 receiver and transmitter. For more
-advanced wireless connections there is also a driver for the Nordic
-Semiconductor NRF24L01+ chip, which allows low-power wireless
-communication of up to 2 Mbps in the 2.4GHz band, and the TI CC1101
-Low-Power Sub-1 GHz RF Transceiver. 
-
-The goal of this project is to provide an efficient programming
-platform for rapid prototyping of "Internet-of-things"-devices. There
-is an Ethernet/Socket with W5100 Ethernet controller device
-driver. This implementation allows streaming direct to the device
-buffers. Cosa also implements a number of IP protocols; DNS, DHCP,
-NTP, HTTP, SNMP and MQTT. 
-
-Unfortunately Cosa is not a beginners entry level programming
-platform, though following some of the design patterns in Cosa will
-help beginners build more complex small scale embedded systems with
-richer concurrency and low power consumption.  
-
-Please follow the development of this project on the blog 
-http://cosa-arduino.blogspot.se and on the Arduino forum,
-http://arduino.cc/forum/index.php/topic,150299.0.html.
-
-Install
--------
-
-The [Cosa zip file]
-(https://github.com/mikaelpatel/Cosa/archive/master.zip) is an Arduino
-core package. 
-
-Arduino 1.0.X: Download and unzip in your Sketchbook hardware
-folder. Create the hardware folder if missing. Path: Sketchbook/hardware/Cosa.     
-
-Arduino 1.5.X: Create a folder named Cosa in your Sketchbook hardware
-folder. Create the hardware folder if missing. Download and unzip in
-your Sketchbook hardware/Cosa folder. Your should have the path;
-Sketchbook/hardware/Cosa/Cosa. Rename the inner Cosa to avr;
-Sketchbook/hardware/Cosa/avr. 
-
-Restart the Arduino IDE and Cosa will show up as a number of boards
-and example sketches.  
-
-For ATtiny a patch is needed for Arduino Windows version to allow
-linking programs larger than 4K; See
-https://github.com/TCWORLD/ATTinyCore/tree/master/PCREL%20Patch%20for%20GCC. 
-Do not forget to program the ATtiny device with the bootloader, i.e.,
-set the fuse bits, before using the device for the first time.  
-
-The Application Programmers Interface (API) documentation is available 
-[online](http://dl.dropbox.com/u/993383/Cosa/doc/html/index.html) and
-compressed for
-[download](http://dl.dropbox.com/u/993383/Cosa/doc.zip). The
-documentation contains a full hyperlinked description of all functions
-in Cosa together with UML graphs of the class hierarchy, include
-dependencies, and much more. 
+The documentation contains a full hyperlinked description of all functions
+in Cosa together with UML graphs of the class hierarchy, includedependencies,
+and much more. 
 
 The provided documentation is generated with doxygen and may also be
 generated for users source code if the Cosa documentation style is
 adapted. See the Doxyfile for configuration of doxygen. 
-
-Drivers
--------
-
-1. DS18B20 Programmable Resolution 1-Wire Digital Thermometer.
-2. AT24CXX Serial EEPROM.
-3. DS1307 Realtime clock with RAM.
-4. PCF8591 2-Wire 8-bit A/D and D/A converter.
-5. ADXL345 Digital Accelerometer.
-6. nRF24L01 Single Chip 2.4GHz Transceiver. 
-7. DHT11 Humidity & Temperature Sensor.
-8. HC-SR04/US-020 Ultrasonic range module.
-9. ST7735, 262K Color Single-Chip TFT Controller.
-10. PCD8544 48x84 pixels matrix LCD controller/driver.
-11. TSOP4838 IR Receiver Modules for Remote Control Systems.
-12. Virtual Wire (VWI) on RF315/433 modules.
-13. HMC5883L 3-Axis Digital Compass IC.
-14. NEXA/HomeEasy Wireless Remote command transmitter/receiver for RF433.
-15. ST7565, 65x132 Dot Matrix LCD Controller/Driver.
-16. Touch capacitive sensor, debounced button and keypad.
-17. Dials with Rotary Encoder.
-18. HD44780 (aka 1602, 2004) LCD Controller/Driver.
-19. DS3231, Extremely Accurate I2C-Integrated RTC/TCXO/Crystal. 
-20. PCF8574/PCF8574A Remote 8-bit I/O expander for I2C-bus with interrupt. 
-21. BMP085 Digital Pressure Sensor.
-22. TI CC1101 Low-Power Sub-1 GHz RF Transceiver.
-23. L3G4200D Digital Gryposcope.
-24. MPU6050 Motion Processing Unit; Digital thermometer, accelerometer
-and gyroscope.
-25. DS1302 Tickle-Charge Timekeeping Chip.
-26. SD card, SPI driver.
-27. RS485 support; master-slave protocol.
-28. RFM69W/HW ISM Transceiver Module.
-29. W5100 Ethernet Controller device driver.
-30. Slave device support for SPI, TWI and OWI.
 
 References
 ----------
@@ -182,120 +52,9 @@ Naming
 * "Cosa fai"; what do you do?
 * "Rete"; network
 
-Note
-----
+Stay tuned
+----------
 
-ATtinyX4/X5/X61, Atmega328P, Atmega1284P, Atmega2560 and Atmega32u4
-based Arduino boards (Uno, Mini, Mini Pro, Micro, Nano, Leonardo,
-LilyPad, LilyPad USB, Mighty, Mega, etc) are supported.
-
-News
-----
-
-2014-03 Support for ThingSpeak client (channel update). Improving the
-ADXL345 accelerometer device driver and example sketch. Adding a Soft
-SPI implementation (only 0/2 mode).       
-
-2014-02 Adding support for coroutines (threads), semaphores and
-mutex. Allow build with GCC 4.8.1. Support for MQTT Client, HTTP
-Server and Client implementation. Additional SNMP agent
-implementation. RTC::Timer for micro-second level time
-events. Improved Time handling with integration with RTC and NTP to
-allow sync.          
-
-2014-01 Adding support for Arduino IDE 1.5.X. Including a Wireless
-interface implementation for RFM69W/HW. Socket interface and device
-driver for W5100 Ethernet Controller. INET network address handler
-support. DHCP, DNS and NTP client/request handler. Simple Telnet port
-handler for trace output.       
-
-2013-12 DS1302 RTC and SD card support. Simple FAT16 library using
-SD. Support for RS485 with master-slave protocol. ATmega32u4 support
-added with USB/CDC.      
-
-2013-11 New device driver for MPU6050 Motion Processing Unit; Digital
-thermometer, accelerometer and gyroscope. Adding support for bitsets
-and Google Protocol Buffers data encoding/decoding. Character and
-token scanner to IOStream. Allowing blocking and non-blocking IOStream
-device mode. Added support for ATtinyX61 and a variant of Base64 for
-encoding of binary data.    
-
-2013-10 Device driver for CC1101 and BMP085 introduced. Introducting
-an abstract Wireless device interface. Refactoring Virtual Wire,
-CC1101 and NRF24L01P to the new interface. Improving support for low
-power mode. Adding a Registry for mapping from path (index sequence)
-to data storage in PROGMEM, EEPROM and SRAM. Mapping may also be to
-Action object in SRAM. Support for LCD TWI port expander
-GY-IICLCD. Wireless IOStream class introduced to allow binding of
-Wireless device driver to IOStream and trace output over
-Wireless. First draft of RETE; data distribution and network
-management protocol. Adding support for L3G4200D digital gyroscope.    
-
-2013-09 Major refactoring of SPI and TWI device driver support.    
-
-2013-08 Updating DHT11/22 device driver. Adding a simple touch
-capacitive sensor.     
-
-2013-07 Introducing an abstract LCD::Device class and refactoring LCD
-device drivers. Benchmarking and optimizing LCD device drivers. Added
-an event driven resistor net keypad handler and support for the
-DFRobot LCD Keypad shield. Boosting LCD performance to 2-6X faster
-than Arduino library. Added a new LCD menu system. Refactored Cosa
-directory structure to match the Arduino core file
-structure. Performance tuning LCD adapters; additional adapters with
-shift register support (SR3W and SR4W). Adding Vigenere autokey and
-RC4 cipher.       
-
-2013-06 HD44780 (1602) LCD device driver. Adding support for
-Sockets. Refactoring NRF24L01P device driver to a
-Socker::Device with support for both connection-less and
-connection-oriented communication. DS3231 device driver and example
-sketches.  Driver for the PCF8574/PCF8574A Remote 8-bit I/O expander
-for I2C-bus with interrupt. Support for 20x4 LCD.    
-
-2013-05 Improving ATtiny support. Adding driver for DHT22. NEXA
-Wireless Remote command transmitter (RF433). Introducing a new
-template class for handling of keyed sets of event handlers. Added
-support for LCD ST7565 with natural text scrolling. Making it easy to
-implement TWI slave devices with TWI::Device. Including support for
-event driven Rotary Encoder handler.   
-
-2013-04 Adding support for HMC5883L 3-axis digital compass. Adding
-abstraction of EEPROM with default handling of internal
-EEPROM. Refactoring AT24CXX driver for new EEPROM
-interface. Implemented 1-wire parasite power mode. Improved DS18B20
-1-wire driver and demo sketches with VWI integration. Added support
-for battery voltage monitoring. New extended mode in VWI with node
-address, sub-net address matching, message sequence numbering and type
-handling. NEXA Wireless Remote command receiver (RF433). Added a
-reliable message passing protocol to the Virtual Wire Interface
-(VWI). The new class VWI::Transceiver supports message acknowledgement
-and auto-retransmission. Full support for message parsing.    
-
-2013-03 Virtual Wire Interface (VWI) for ATtiny. VWI IOStream Device
-to allow streaming of output over Virtual Wire. Introducing Manchester
-Phase Encoder (MPE) based on VWI. Introducing class for Power
-Management and Sleep Modes. Refactoring VWI to allow easy update of
-codecs; VirtualWire, Manchester and Fixed Bitstuffing. Additional
-codex; Block Coding, B4B5. New VWI example sketches with
-retransmission; simple client/server example. Introducing an interface
-for interrupt handlers, and support for pin change interrupts. New
-directory structure for handling boards. Moving documentation and
-references to dropbox. Reducing size of download from github.   
-
-2013-02 Adding doxygen generated documentation (doc.zip). GLCD font
-support added. IR remote receiver initial example. Adding input/output
-operators to IOStream, Pins and SPI. More detailed benchmarks and
-comparison with Arduino added. IOStream driver for PCD8544 48x84
-pixels matrix LCD controller with support for fonts and icons.
-TSOP4838 IR Receiver Modules support (LG remote example). Improving
-PCD8544 driver with OffScreen canvas. UART receiver,
-Device::getchar(), implemented. Adding generic circlic buffer for
-IOStream::Device. Adding support for ATtinyX5. Simple ATtiny monitor
-included. Adding support for RC Servo. Adding support for
-ATmega1284P/Mighty boards. Refactoring and porting VirtualWire to
-Cosa.    
-
-2013-01 Arduino Mega 2560 initial port. UTFT font support
-added. Proto-threads implemented. Draw/fill round rectangle added to
-Canvas.    
+Please follow the development of this project on the blog 
+http://cosa-arduino.blogspot.se and on the Arduino forum,
+http://arduino.cc/forum/index.php/topic,150299.0.html.    

--- a/documentation/01-cosa.md
+++ b/documentation/01-cosa.md
@@ -1,0 +1,79 @@
+# Che Cosa?
+
+Cosa is an object-oriented platform for Arduino. It replaces the Arduino
+and Wiring library with a large set of integrated classes that support 
+the full range of AVR/ATmega/ATtiny internal hardware modules; all pin
+modes, Digital, and Analog Pins, External and Pin Change Interrupts,
+Analog Comparator, PWM, Watchdog, Timer0 (RTC), Timer1 (Servo), UART, USI,
+SPI, TWI and EEPROM.   
+
+Cosa is implemented as an Arduino IDE core. The Cosa platform can be
+used with almost all Arduino boards and ATtiny/ATmega processors. All
+classes may be compiled for all variants.
+
+Though object-oriented with optional operator overloading syntax,
+Cosa is between 2-10X faster than Arduino with regard to digital pin
+functions. This comes with a small price-tag; memory, 4 bytes per
+digital pin and 12 bytes per analog pin. Cosa analog pin objects
+holds the latest sample and allows an event handler. See the
+benchmarks in the examples directory for further details.
+
+Cosa contains several data streaming formats for message passing and
+data streaming. Google Protocol Buffers are supported together with a
+data streaming format (Ciao) for encoding of C/C++ language data types
+such as strings, integer and floating pointer numbers into a binary
+format. It may be used for a number of applications; tracing, remote
+procedure calls, data exchange between Arduino devices, etc. The
+format allows user data types to be defined and values exchanged
+without additional encoding. The stream header itself is a pre-defined
+serializable data type. Ciao is used to define an Arduino monitoring
+and control language (Cosa fai) which has much in common with
+Firmata. 
+
+The primary programming paradigm is object-oriented and
+state-machine/event driven with proto-threads or multi-tasking. There
+is a large number of device drivers available for SPI, I2C (TWI) and
+1-Wire (OWI). A strict directory structure is used to organize the
+Cosa/driver source code. Sub-directories are used for each driver
+type. This allows a foundation for scaling and configuration.
+
+Cosa uses the Arduino IDE and build system. Cosa classes are included
+with prefix, e.g. "Cosa/FileName.hh". It is possible to use both
+Arduino and Cosa functions together, though in some cases the Cosa
+objects may become inconsistent. 
+
+To improve debugging and testing there is assert/trace/syslog style
+support. The IOStream class allows output to both serial wire/wireless
+communication (UART/VWIO) and small TFT displays (such as the ST7735,
+ST7565, HD44780, and PCD8544). The Cosa LCD class extends
+IOStream::Device with additional common LCD functions. The Cosa LCD
+Menu class adds a simple framework for creating menu systems with
+program state such as integer ranges, bitsets and enumeration
+variables. All menu data structures are stored in program memory and
+the SRAM requirement is minimum. A macro set hides the details of
+creating the data structures in program memory.
+
+The drawing Canvas class supports basic drawing operation
+and scripting to reduce program memory footprint. The Canvas class
+also supports drawing of icons and multiple fonts (GLCD and UTFT). 
+
+The popular VirtualWire library has been refactored to the
+object-oriented style of Cosa (VWI) and extended with three additional
+codecs; Manchester, 4B5B and Bitstuffing. This allows basic ultra
+cheap wireless nodes with RF315/433 receiver and transmitter. For more
+advanced wireless connections there is also a driver for the Nordic
+Semiconductor NRF24L01+ chip, which allows low-power wireless
+communication of up to 2 Mbps in the 2.4GHz band, and the TI CC1101
+Low-Power Sub-1 GHz RF Transceiver. 
+
+The goal of this project is to provide an efficient programming
+platform for rapid prototyping of "Internet-of-things"-devices. There
+is an Ethernet/Socket with W5100 Ethernet controller device
+driver. This implementation allows streaming direct to the device
+buffers. Cosa also implements a number of IP protocols; DNS, DHCP,
+NTP, HTTP, SNMP and MQTT. 
+
+Unfortunately Cosa is not a beginners entry level programming
+platform, though following some of the design patterns in Cosa will
+help beginners build more complex small scale embedded systems with
+richer concurrency and low power consumption.

--- a/documentation/02-install.md
+++ b/documentation/02-install.md
@@ -1,0 +1,40 @@
+# How to install Cosa ?
+
+## Via GIT
+
+```shell
+cd <custom_path>/sketchbook
+mkdir hardware # Create the hardware folder if missing
+cd hardware
+git clone git@github.com:mikaelpatel/Cosa.git
+```
+
+Then you can update the library by using:
+
+```shell
+git pull origin master
+```
+
+## Via Archives
+
+### Step 1
+
+* Download the [Cosa zip file](../archive/master.zip)
+* Create the hardware folder if missing (<custom_path>/sketchbook/hardware)
+* Unzip the files to your hardware folder
+
+### Step 2 (For Arduino 1.5.x only)    
+
+* Rename inner `Cosa` folder (<custom_path>/sketchbook/hardware/Cosa/Cosa) to
+`avr` (<custom_path>/sketchbook/hardware/Cosa/avr)
+
+### Step 3 (For Attiny users on Windows version only)
+
+* Install [this patch](https://github.com/TCWORLD/ATTinyCore/tree/master/PCREL%20Patch%20for%20GCC)
+
+Do not forget to program the ATtiny device with the bootloader, i.e.,
+set the fuse bits, before using the device for the first time.
+
+### Step 4
+
+* Restart the Arduino IDE and Cosa will show up as a number of boards and example sketches.  

--- a/documentation/03-boards.md
+++ b/documentation/03-boards.md
@@ -1,0 +1,25 @@
+# Cosa's supported boards & chips
+
+## Arduino Boards
+
+* [Leonardo](http://arduino.cc/en/Main/ArduinoBoardLeonardo#.UxWVeNv0u1E)
+* [LilyPad](http://arduino.cc/en/Main/arduinoBoardLilyPad#.UxWW9tv0u1E)
+* [LilyPad USB](http://arduino.cc/en/Main/ArduinoBoardLilyPadUSB#.UxWXUdv0u1E)
+* [Mega](http://arduino.cc/en/Main/ArduinoBoardMega#.UxWVpNv0u1E)
+* [Micro](http://arduino.cc/en/Main/ArduinoBoardMicro#.UxWVw9v0u1E)
+* Mighty
+* [Mini](http://arduino.cc/en/Main/ArduinoBoardMini#.UxWWR9v0u1E)
+* [Mini Pro](http://arduino.cc/en/Main/ArduinoBoardProMini#.UxWWb9v0u1E)
+* [Nano](http://arduino.cc/en/Main/ArduinoBoardNano#.UxWWh9v0u1E)
+* [Uno](http://arduino.cc/en/Main/ArduinoBoardUno#.UxWWodv0u1F)
+* Any other boards with a [compliant chips](#chips)
+
+## Chips
+
+* [ATmega 328P](http://www.atmel.com/Images/Atmel-8271-8-bit-AVR-Microcontroller-ATmega48A-48PA-88A-88PA-168A-168PA-328-328P_datasheet.pdf)
+* [ATmega 1284P](http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf)
+* [ATmega 2560](http://www.atmel.com/Images/doc2549.pdf)
+* [ATmega 32u4](http://www.atmel.com/Images/doc7766.pdf)
+* [ATtiny 24 / 44 / 84](http://www.atmel.com/Images/doc8006.pdf)
+* [ATtiny 25 / 45 / 85](http://www.atmel.com/Images/Atmel-2586-AVR-8-bit-Microcontroller-ATtiny25-ATtiny45-ATtiny85_Datasheet.pdf)
+* [ATtiny 261 / 461/ 861](http://www.atmel.com/Images/Atmel-2588-8-bit-AVR-Microcontrollers-tinyAVR-ATtiny261-ATtiny461-ATtiny861_Datasheet.pdf)

--- a/documentation/04-drivers.md
+++ b/documentation/04-drivers.md
@@ -1,0 +1,56 @@
+# Cosa's built-in drivers
+
+1. [DS18B20](http://datasheets.maximintegrated.com/en/ds/DS18B20.pdf) Programmable
+Resolution [1-Wire](http://en.wikipedia.org/wiki/1-Wire) Digital Thermometer.
+2. [AT24CXX](http://www.atmel.com/products/Memories/serial/i2c.aspx) Serial
+[EEPROM](http://en.wikipedia.org/wiki/EEPROM).
+3. [DS1307](http://datasheets.maximintegrated.com/en/ds/DS1307.pdf)
+[Realtime clock](http://en.wikipedia.org/wiki/Real-time_clock) with RAM.
+4. [PCF8591](http://www.nxp.com/documents/data_sheet/PCF8591.pdf) 2-Wire 8-bit A/D
+and D/A converter.
+5. [ADXL345](http://www.analog.com/static/imported-files/data_sheets/ADXL345.pdf)
+Digital Accelerometer.
+6. [nRF24L01](http://www.nordicsemi.com/eng/Products/2.4GHz-RF/nRF24L01) Single
+Chip 2.4GHz Transceiver. 
+7. [DHT11](http://www.micro4you.com/files/sensor/DHT11.pdf) Humidity & Temperature
+Sensor.
+8. [HC-SR04/US-020](http://www.micropik.com/PDF/HCSR04.pdf) Ultrasonic range module.
+9. [ST7735](ftp://imall.iteadstudio.com/IM120419001_ITDB02_1.8SP/DS_ST7735.pdf), 262K
+Color Single-Chip TFT Controller.
+10. [PCD8544](https://www.sparkfun.com/datasheets/LCD/Monochrome/Nokia5110.pdf) 48x84
+pixels matrix LCD controller/driver.
+11. [TSOP4838](http://www.vishay.com/docs/82459/tsop48.pdf) IR Receiver Modules for
+Remote Control Systems.
+12. [Virtual Wire (VWI)](http://www.airspayce.com/mikem/arduino/VirtualWire/) on
+RF315/433 modules.
+13. [HMC5883L](http://www51.honeywell.com/aero/common/documents/myaerospacecatalog-documents/Defense_Brochures-documents/HMC5883L_3-Axis_Digital_Compass_IC.pdf) 3-Axis Digital Compass IC.
+14. [NEXA/HomeEasy](http://www.homeeasy.eu/) Wireless Remote command transmitter/receiver
+for RF433.
+15. [ST7565](http://akizukidenshi.com/download/ds/sitronix/st7565r.pdf), 65x132 Dot
+Matrix LCD Controller/Driver.
+16. [Touch capacitive sensor](http://en.wikipedia.org/wiki/Capacitive_sensing), debounced
+button and keypad.
+17. Dials with [Rotary Encoder](http://en.wikipedia.org/wiki/Rotary_encoder).
+18. [HD44780](https://www.sparkfun.com/datasheets/LCD/HD44780.pdf) (aka 1602, 2004)
+LCD Controller/Driver.
+19. [DS3231](http://www.maximintegrated.com/datasheet/index.mvp/id/4627), Extremely
+Accurate I2C-Integrated RTC/TCXO/Crystal. 
+20. [PCF8574/PCF8574A](http://www.nxp.com/documents/data_sheet/PCF8574.pdf)
+Remote 8-bit I/O expander for I2C-bus with interrupt. 
+21. [BMP085](https://www.sparkfun.com/datasheets/Components/General/BST-BMP085-DS000-05.pdf)
+Digital Pressure Sensor.
+22. [TI CC1101](http://www.ti.com/lit/ds/symlink/cc1101.pdf) Low-Power Sub-1 GHz RF
+Transceiver.
+23. [L3G4200D](http://dlnmh9ip6v2uc.cloudfront.net/datasheets/Sensors/Gyros/3-Axis/CD00265057.pdf)
+Digital Gryposcope.
+24. [MPU6050](http://dlnmh9ip6v2uc.cloudfront.net/datasheets/Components/General%20IC/PS-MPU-6000A.pdf)
+Motion Processing Unit; Digital thermometer, accelerometer and gyroscope.
+25. [DS1302](http://datasheets.maximintegrated.com/en/ds/DS1302.pdf) Tickle-Charge
+Timekeeping Chip.
+26. SD card, [SPI](http://fr.wikipedia.org/wiki/Serial_Peripheral_Interface) driver.
+27. [RS485](http://en.wikipedia.org/wiki/RS-485) support; master-slave protocol.
+28. [RFM69W/HW](http://www.hoperf.com/upload/rf/RFM69W-V1.3.pdf) [ISM](http://en.wikipedia.org/wiki/ISM_band) Transceiver Module.
+29. [W5100](https://www.sparkfun.com/datasheets/DevTools/Arduino/W5100_Datasheet_v1_1_6.pdf)
+Ethernet Controller device driver.
+30. Slave device support for [SPI](http://fr.wikipedia.org/wiki/Serial_Peripheral_Interface), TWI and [OWI](http://en.wikipedia.org/wiki/1-Wire).
+

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,7 @@
+# Cosa's Documentation
+
+* [Che Cosa?](./01-cosa.md)
+* [Install](./02-install.md)
+* [Supported boards & chips](./03-boards.md)
+* [Built-in drivers](./04-drivers.md)
+* [Changes Log](./changelog.md)

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -1,0 +1,107 @@
+Cosa's changelog
+================
+
+2014-03 Support for ThingSpeak client (channel update). Improving the
+ADXL345 accelerometer device driver and example sketch. Adding a Soft
+SPI implementation (only 0/2 mode).       
+
+2014-02 Adding support for coroutines (threads), semaphores and
+mutex. Allow build with GCC 4.8.1. Support for MQTT Client, HTTP
+Server and Client implementation. Additional SNMP agent
+implementation. RTC::Timer for micro-second level time
+events. Improved Time handling with integration with RTC and NTP to
+allow sync.          
+
+2014-01 Adding support for Arduino IDE 1.5.X. Including a Wireless
+interface implementation for RFM69W/HW. Socket interface and device
+driver for W5100 Ethernet Controller. INET network address handler
+support. DHCP, DNS and NTP client/request handler. Simple Telnet port
+handler for trace output.       
+
+2013-12 DS1302 RTC and SD card support. Simple FAT16 library using
+SD. Support for RS485 with master-slave protocol. ATmega32u4 support
+added with USB/CDC.      
+
+2013-11 New device driver for MPU6050 Motion Processing Unit; Digital
+thermometer, accelerometer and gyroscope. Adding support for bitsets
+and Google Protocol Buffers data encoding/decoding. Character and
+token scanner to IOStream. Allowing blocking and non-blocking IOStream
+device mode. Added support for ATtinyX61 and a variant of Base64 for
+encoding of binary data.    
+
+2013-10 Device driver for CC1101 and BMP085 introduced. Introducting
+an abstract Wireless device interface. Refactoring Virtual Wire,
+CC1101 and NRF24L01P to the new interface. Improving support for low
+power mode. Adding a Registry for mapping from path (index sequence)
+to data storage in PROGMEM, EEPROM and SRAM. Mapping may also be to
+Action object in SRAM. Support for LCD TWI port expander
+GY-IICLCD. Wireless IOStream class introduced to allow binding of
+Wireless device driver to IOStream and trace output over
+Wireless. First draft of RETE; data distribution and network
+management protocol. Adding support for L3G4200D digital gyroscope.    
+
+2013-09 Major refactoring of SPI and TWI device driver support.    
+
+2013-08 Updating DHT11/22 device driver. Adding a simple touch
+capacitive sensor.     
+
+2013-07 Introducing an abstract LCD::Device class and refactoring LCD
+device drivers. Benchmarking and optimizing LCD device drivers. Added
+an event driven resistor net keypad handler and support for the
+DFRobot LCD Keypad shield. Boosting LCD performance to 2-6X faster
+than Arduino library. Added a new LCD menu system. Refactored Cosa
+directory structure to match the Arduino core file
+structure. Performance tuning LCD adapters; additional adapters with
+shift register support (SR3W and SR4W). Adding Vigenere autokey and
+RC4 cipher.       
+
+2013-06 HD44780 (1602) LCD device driver. Adding support for
+Sockets. Refactoring NRF24L01P device driver to a
+Socker::Device with support for both connection-less and
+connection-oriented communication. DS3231 device driver and example
+sketches.  Driver for the PCF8574/PCF8574A Remote 8-bit I/O expander
+for I2C-bus with interrupt. Support for 20x4 LCD.    
+
+2013-05 Improving ATtiny support. Adding driver for DHT22. NEXA
+Wireless Remote command transmitter (RF433). Introducing a new
+template class for handling of keyed sets of event handlers. Added
+support for LCD ST7565 with natural text scrolling. Making it easy to
+implement TWI slave devices with TWI::Device. Including support for
+event driven Rotary Encoder handler.   
+
+2013-04 Adding support for HMC5883L 3-axis digital compass. Adding
+abstraction of EEPROM with default handling of internal
+EEPROM. Refactoring AT24CXX driver for new EEPROM
+interface. Implemented 1-wire parasite power mode. Improved DS18B20
+1-wire driver and demo sketches with VWI integration. Added support
+for battery voltage monitoring. New extended mode in VWI with node
+address, sub-net address matching, message sequence numbering and type
+handling. NEXA Wireless Remote command receiver (RF433). Added a
+reliable message passing protocol to the Virtual Wire Interface
+(VWI). The new class VWI::Transceiver supports message acknowledgement
+and auto-retransmission. Full support for message parsing.    
+
+2013-03 Virtual Wire Interface (VWI) for ATtiny. VWI IOStream Device
+to allow streaming of output over Virtual Wire. Introducing Manchester
+Phase Encoder (MPE) based on VWI. Introducing class for Power
+Management and Sleep Modes. Refactoring VWI to allow easy update of
+codecs; VirtualWire, Manchester and Fixed Bitstuffing. Additional
+codex; Block Coding, B4B5. New VWI example sketches with
+retransmission; simple client/server example. Introducing an interface
+for interrupt handlers, and support for pin change interrupts. New
+directory structure for handling boards. Moving documentation and
+references to dropbox. Reducing size of download from github.   
+
+2013-02 Adding doxygen generated documentation (doc.zip). GLCD font
+support added. IR remote receiver initial example. Adding input/output
+operators to IOStream, Pins and SPI. More detailed benchmarks and
+comparison with Arduino added. IOStream driver for PCD8544 48x84
+pixels matrix LCD controller with support for fonts and icons.
+TSOP4838 IR Receiver Modules support (LG remote example). Improving
+PCD8544 driver with OffScreen canvas. UART receiver,
+Device::getchar(), implemented. Adding generic circlic buffer for
+IOStream::Device. Adding support for ATtinyX5. Simple ATtiny monitor
+included. Adding support for RC Servo. Adding support for
+ATmega1284P/Mighty boards. Refactoring and porting VirtualWire to
+Cosa.    
+=======


### PR DESCRIPTION
Hi Mikeal,

With this PR, i'm trying to improve the library documentation:
- Make the README lighter with only headlines about the library
- Move the advanced documentation into a "documentation" folder with it's own index
- Add many links to definition / datasheet for the boards, chips, drivers and protocols.
- Split the install process to a "step by step"
- Move the changelog a separated file

By doing this, i think it will ease the learning process, increase library SEO and make the documentation more "maintainable".

Cheers,

Jérémy
