### PR TITLE
Improve use of SD status; More flexible INIT timing

### DIFF
--- a/cores/cosa/Cosa/SPI/Driver/SD.hh
+++ b/cores/cosa/Cosa/SPI/Driver/SD.hh
@@ -222,6 +222,8 @@ protected:
       uint8_t reserved:1;
     };
     R1(uint8_t value = 0) { as_uint8 = value; }
+    bool error() const { return ((as_uint8 & 0xFC) != 0); };
+    bool ready() const { return (as_uint8 == 0); };
   };
 
   /** R2 (Extended status). */
@@ -302,7 +304,7 @@ protected:
   static const uint8_t INIT_PULSES = 10;
 
   /** Internal number of retry. */
-  static const uint8_t INIT_RETRY = 10;
+  static const uint16_t INIT_RETRY = 20000;
   static const uint8_t RESPONSE_RETRY = 100;
 
   /** Response from latest command. */


### PR DESCRIPTION
The R1 status that comes back from commands contains several error bits
and one IDLE state bit.  Checking for errors involves only the error
bits.

The IDLE state bit is used to determine whether the initialization
process is completed.  Some commands can be issued during the process,
but others must wait until the SD card is READY (i.e. not IDLE).

The standard allows up to 2s for the initialization process to complete.
The command can return immediately, but the process continues.

I suspect that faster cards may be READY sooner than the SEND_OP_COND
(e.g., at SEND_IF_COND), so checking the IDLE bit makes it fragile.
Again, the error bits have the error information.

To accommodate slower cards, the SEND_OP_COND must keep trying for up to
2s (i.e., 1000 \* INIT_TIMEOUT).  Here, I inserted a delay to pace the
retries, and to make it more immune to processor speed.  It could be
changed to watch `millis()` instead.
