### PR TITLE
Use C++ and C++ flags for .cpp source in libraries

### DIFF
--- a/build/Arduino-Makefile/Arduino.mk
+++ b/build/Arduino-Makefile/Arduino.mk
@@ -967,7 +967,7 @@ $(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.c
 
 $(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.cpp
 	@$(MKDIR) $(dir $@)
-	$(CC) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+	$(CXX) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 $(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.S
 	@$(MKDIR) $(dir $@)
@@ -975,7 +975,7 @@ $(OBJDIR)/libs/%.o: $(ARDUINO_LIB_PATH)/%.S
 
 $(OBJDIR)/libs/%.o: $(USER_LIB_PATH)/%.cpp
 	@$(MKDIR) $(dir $@)
-	$(CC) -MMD -c $(CPPFLAGS) $(CFLAGS) $< -o $@
+	$(CXX) -MMD -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 $(OBJDIR)/libs/%.o: $(USER_LIB_PATH)/%.c
 	@$(MKDIR) $(dir $@)


### PR DESCRIPTION
.cpp files in libraries were being compiled with C and C flags which
caused compile errors when Watchdog.hh was included because it includes
Queue.h that depends on C++ for static_assert.
