### PR TITLE
Update PWMPin.cpp

### DIFF
--- a/cores/cosa/Cosa/PWMPin.cpp
+++ b/cores/cosa/Cosa/PWMPin.cpp
@@ -552,15 +552,15 @@ PWMPin::set(uint8_t duty)
 {
   switch (m_pin) {
   case Board::PWM0:
-    bit_set(TCCR1C, COM1A0);
+    bit_set(TCCR1C, COM1A1);
     OCR1A = duty;
     return;
   case Board::PWM1:
-    bit_set(TCCR1C, COM1B0);
+    bit_set(TCCR1C, COM1B1);
     OCR1B = duty;
     return;
   case Board::PWM2:
-    bit_set(TCCR1C, COM1D0);
+    bit_set(TCCR1C, COM1D1);
     OCR1D = duty;
     return;
   default:


### PR DESCRIPTION
COM1x0 enable both, direct & complementary PWM output. COM1x1 only the direct one.
