### PR TITLE
Fix CDC::begin hang when no host is present

### DIFF
--- a/cores/cosa/Cosa/IOStream/Driver/CDC.cpp
+++ b/cores/cosa/Cosa/IOStream/Driver/CDC.cpp
@@ -128,7 +128,7 @@ CDC::begin(uint32_t baudrate, uint8_t format)
   UNUSED(baudrate);
   UNUSED(format);
   if (!Watchdog::is_initiated()) Watchdog::begin();
-  USBDevice.attach();
+  if (!USBDevice.attach()) return (false);
   for (uint8_t retry = 0; retry < 30; retry++) {
     if (_usbLineInfo.lineState > 0) return (true);
     delay(200);

--- a/cores/cosa/Cosa/USB/API.h
+++ b/cores/cosa/Cosa/USB/API.h
@@ -31,7 +31,7 @@ class USBDevice_
  public:
   USBDevice_();
   bool configured();
-  void attach();
+  bool attach();
   void detach();
   void poll();
 };


### PR DESCRIPTION
When no host is present CDC::begin hangs in USBDevice::attach.  This change waits 2 seconds before giving up on the host.  If no host is connected within that time USB data is disabled but USB power regulator is left on in case power comes from a USB power adapter.

I have a 32U4.  When I power from a USB adapter CDC::begin hangs.  Since this is the usual trace device this would be a normal situation.

Although this has been tested with 32U4 I'm unsure about the change being complete.  I'm also unsure about the 2 second timeout; perhaps it should be longer.

While I haven't tested, I assume the same issue is present if power comes from a source other than USB.
