### PR TITLE
Fix CDC auto-reset for Mac OSX

### DIFF
--- a/build/Arduino-Makefile/bin/ard-reset-arduino
+++ b/build/Arduino-Makefile/bin/ard-reset-arduino
@@ -21,6 +21,8 @@ if args.caterina:
     ser.close()
     ser.setBaudrate(1200)
     ser.open()
+    ser.setDTR(False)
+    sleep(1)
     ser.close()
     sleep(1)
 

--- a/cores/cosa/Cosa/IOStream/Driver/CDC.cpp
+++ b/cores/cosa/Cosa/IOStream/Driver/CDC.cpp
@@ -110,7 +110,7 @@ CDC_Setup(Setup& setup)
 	  // Most OSs do some intermediate steps when configuring
 	  // ports and DTR can twiggle more than once before
 	  // stabilizing. To avoid spurious resets we set the watchdog
-	  // to 250ms and eventually cancel if DTR goes back high.
+	  // to 120ms and eventually cancel if DTR goes back high.
 	  wdt_disable();
 	  wdt_reset();
 	  *(uint16_t *)0x0800 = 0x0;


### PR DESCRIPTION
The OSX USB driver apparently behaves differently than other platforms
with regard to baud rate and DTR handling.  This fix forces DTR low for
1 second in ard-reset-arduino to guarantee that Cosa will reset
regardless of host platform behavior.  Also corrected a comment about
the watchdog time to match the wdt_enable.
