### PR TITLE
Time and RTC changes

### DIFF
--- a/cores/cosa/Cosa/RTC.cpp
+++ b/cores/cosa/Cosa/RTC.cpp
@@ -117,14 +117,12 @@ ISR(TIMER0_OVF_vect)
   // Skip tick if accumulated error is greater than tick time
   if (RTC::s_uerror >= US_PER_TICK)
     RTC::s_uerror -= US_PER_TICK;
-  else {
+  else if (RTC::s_ticks == TICKS_PER_SEC-1) {
+    RTC::s_ticks = 0;
+    RTC::s_sec++;
+    RTC::s_uerror += US_PER_SEC_ERROR;
+  } else
     RTC::s_ticks++;
-    if (RTC::s_ticks == TICKS_PER_SEC) {
-      RTC::s_ticks = 0;
-      RTC::s_sec += 1;
-      RTC::s_uerror += US_PER_SEC_ERROR;
-    }
-  }
 
   // Check for extension of the interrupt handler
   RTC::InterruptHandler fn = RTC::s_handler;

--- a/cores/cosa/Cosa/RTC.hh
+++ b/cores/cosa/Cosa/RTC.hh
@@ -74,6 +74,8 @@ public:
   {
     synchronized {
       s_sec = sec;
+      s_ticks = 0;
+      s_uerror = 0;
     }
   }
 
@@ -94,6 +96,18 @@ public:
    * @return micro-seconds.
    */
   static uint32_t micros();
+
+  /**
+   * Set the current clock in micro-seconds.
+   * @param[in] usec.
+   */
+  static void micros( uint32_t usec )
+  {
+    synchronized {
+      s_uticks = usec;
+    }
+  }
+
 
   /**
    * Return the current clock in milli-seconds.

--- a/cores/cosa/Cosa/Time.cpp
+++ b/cores/cosa/Cosa/Time.cpp
@@ -20,7 +20,7 @@
 
 #include "Cosa/Time.hh"
 
-IOStream& operator<<(IOStream& outs, time_t& t)
+IOStream& operator<<(IOStream& outs, const time_t& t)
 {
   outs << time_t::full_year( t.year ) << '-';
   if (t.month < 10) outs << '0';

--- a/cores/cosa/Cosa/Time.hh
+++ b/cores/cosa/Cosa/Time.hh
@@ -271,7 +271,7 @@ struct time_t {
 protected:
   static uint16_t s_epoch_year;
   static uint8_t epoch_offset;
-};
+} __attribute__((packed));
 
 /**
  * Print the date/time to the given stream with the format "YYYY-MM-DD HH:MM:SS".
@@ -279,5 +279,6 @@ protected:
  * @param[in] t time structure.
  * @return iostream.
  */
-IOStream& operator<<(IOStream& outs, time_t& t);
+IOStream& operator<<(IOStream& outs, const time_t& t);
+
 #endif

--- a/examples/Benchmarks/CosaBenchmarkRTCTimer/CosaBenchmarkRTCTimer.ino
+++ b/examples/Benchmarks/CosaBenchmarkRTCTimer/CosaBenchmarkRTCTimer.ino
@@ -239,9 +239,7 @@ void setup()
 		 actual);
   uart.flush();
   
-  synchronized {
-    RTC::s_uticks = 0xFFFFF000UL; // 4095uS 'til rolloover
-  };
+  RTC::micros( 0xFFFFF000UL ); // 4095uS 'til rolloover
   expected = 5000;  // anywhere past the rolloever...
  
   Simple::flag = false;


### PR DESCRIPTION
CosaBenchmarkRTCTimer won't compile: needs `micros` mutator in RTC.

Modified `RTC::seconds` so that it restarts the ticks and error part of the second.  This is probably the intent of `seconds` mutator anyway: _NOW_ it's this second.  Otherwise, it could unexpectedly rollover into the next second shortly after the call, or skip a tick because the error had been accumulating for a while.

Minor changes to `time_t` to allow streaming `const time_t` and packing in enclosing structures/classes.
