### PR TITLE
Fix make size checking

### DIFF
--- a/build/Arduino-Makefile/Arduino.mk
+++ b/build/Arduino-Makefile/Arduino.mk
@@ -1054,7 +1054,7 @@ $(OBJDIR)/%.hex: $(OBJDIR)/%.elf $(COMMON_DEPS)
 	@$(ECHO) '\n'
 	$(call avr_size,$<,$@)
 ifneq ($(strip $(HEX_MAXIMUM_SIZE)),)
-	@if [ `$(SIZE) $@ | awk 'FNR == 2 {print $$2}'` -le $(HEX_MAXIMUM_SIZE) ]; then touch $@.sizeok; fi
+	@if [ `$(SIZE) $@ | awk 'FNR == 2 {print $$2}'` -le $(HEX_MAXIMUM_SIZE) ]; then touch $@.sizeok; else rm -f $@.sizeok; fi
 else
 	@$(ECHO) "Maximum flash memory of $(BOARD_TAG) is not specified. Make sure the size of $@ is less than $(BOARD_TAG)\'s flash memory"
 	@touch $@.sizeok


### PR DESCRIPTION
If a build is successful and required flash size was ok it creates a
file with a suffix of ‘.sizeok’. This is used to allow uploads later.
If the application grows and subsequent build exceeds the size limit
the ‘.sizeok’ file was NOT removed resulting in an upload that
overwrites the bootloader.  ‘.sizeok’ was only being removed via
‘clean’.  The fix now removes ‘.sizeok’ correctly.
