### PR TITLE
Fix hang in Watchdog

### DIFF
--- a/cores/cosa/Cosa/Watchdog.cpp
+++ b/cores/cosa/Cosa/Watchdog.cpp
@@ -70,14 +70,15 @@ Watchdog::begin(uint16_t ms,
 void
 Watchdog::delay(uint32_t ms)
 {
-  uint32_t ticks = (ms + (ms_per_tick() / 2)) / ms_per_tick();
+  int32_t ticks = (ms + (ms_per_tick() / 2)) / ms_per_tick();
   uint8_t key = lock();
-  uint32_t stop = s_ticks + (ticks == 0 ? 1 : ticks);
-  while (s_ticks != stop) {
+  uint32_t stop = s_ticks + ticks;
+  do {
     unlock(key);
     yield();
     key = lock();
-  }
+    ticks = stop - s_ticks;
+  } while (ticks > 0);
   unlock(key);
 }
 


### PR DESCRIPTION
Interrupt processing after `unlock` may allow `s_ticks` to advance twice, causing the loop test to miss when `s_ticks == stop`.  Instead, use signed comparison of remaining ticks.  Well, I suspect that's what is happening.  Test code has isolated the hang to inside `Watchdog::await`, but without a JTAG I cannot narrow it down any further.  This fix _appears_ to eliminate the hang.

This fix retains the behavior of always yielding at least once.
