### PR TITLE
Fix shell scripts for older Arduino

### DIFF
--- a/cores/cosa/Cosa/Shell.cpp
+++ b/cores/cosa/Cosa/Shell.cpp
@@ -119,7 +119,7 @@ Shell::execute(char* buf)
   m_argv = argv;
 
   // Check if the action is a script
-  const char* sp  = (const char*) cp->action;
+  const char* sp  = (const char*) pgm_read_word(&cp->action);
   if (strncmp_P(SHELL_SCRIPT_MAGIC, sp, sizeof(SHELL_SCRIPT_MAGIC) - 1) == 0) 
     return (script(sp, argc, argv));
 

--- a/cores/cosa/Cosa/Shell.hh
+++ b/cores/cosa/Cosa/Shell.hh
@@ -344,7 +344,7 @@ protected:
  */
 #define SHELL_SCRIPT_END(command) \
   ; \
-  static Shell::action_fn command ## _action = (Shell::action_fn) command ## _SCRIPT;
+  static const Shell::action_fn command ## _action __PROGMEM = (Shell::action_fn) command ## _SCRIPT;
 
 /**
  * Support macro to start the definition of commands in program memory.


### PR DESCRIPTION
Fix for Arduino 1.0.x errors when using shell scripts.
