### PR TITLE
Use env to call correct python executable

### DIFF
--- a/build/miniterm.py
+++ b/build/miniterm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Very simple serial terminal
 # (C)2002-2009 Chris Liechti <cliechti@gmx.net>


### PR DESCRIPTION
Make sure to call the correct python using env. If the user has multiple pythons installed, or installed in a nonstandard location, this will make sure that the python in PATH is used.