### PR TITLE
Update CosaTWIremotePinSlave. 

### DIFF
--- a/examples/TWI/CosaTWIremotePinSlave/CosaTWIremotePinSlave.ino
+++ b/examples/TWI/CosaTWIremotePinSlave/CosaTWIremotePinSlave.ino
@@ -57,18 +57,13 @@ private:
   uint8_t m_buf[BUF_MAX];
 
 public:
-  RemotePinSlave() : TWI::Slave(ADDR) {}
+  RemotePinSlave() : TWI::Slave(ADDR)
+  {
+    set_write_buf(m_buf, sizeof(m_buf));
+    set_read_buf(m_buf, sizeof(m_buf));
+  }
   virtual void on_request(void* buf, size_t size);
-  void begin();
 };
-
-void
-RemotePinSlave::begin() 
-{ 
-  set_write_buf(m_buf, sizeof(m_buf));
-  set_read_buf(m_buf, sizeof(m_buf));
-  twi.begin(this); 
-}
 
 void
 RemotePinSlave::on_request(void* buf, size_t size)
@@ -94,3 +89,7 @@ void setup()
   slave.begin();
 }
 
+void loop()
+{
+  Event::service();
+}


### PR DESCRIPTION
See issue #305 and commit 05e9ec485743e8027b1f18f7f3212a91b3d36841.

The removal of RemotePinSlave::begin and moving of set_*_buf is to fix setting of slave address.
Would otherwise be 0x7f no matter what the ADDR was set to.
No idea of why this fixes the issue, or why there was an issue in the first place, but comparing this sketch to the CosaTWIslave resulted in the following changes.