### PR TITLE
Update the extended fuses from 0xFD to 0x05. Only last 3 bits are actually in use.

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -510,7 +510,7 @@ atmega328-8.upload.maximum_eeprom_size=1024
 atmega328-8.bootloader.tool=avrdude
 atmega328-8.bootloader.low_fuses=0xE2
 atmega328-8.bootloader.high_fuses=0xDE
-atmega328-8.bootloader.extended_fuses=0xFD
+atmega328-8.bootloader.extended_fuses=0x05
 
 atmega328-8.build.mcu=atmega328p
 atmega328-8.build.f_cpu=8000000L

--- a/boards/breadboard.txt
+++ b/boards/breadboard.txt
@@ -108,7 +108,7 @@ atmega328-8.upload.maximum_eeprom_size=1024
 atmega328-8.bootloader.tool=avrdude
 atmega328-8.bootloader.low_fuses=0xE2
 atmega328-8.bootloader.high_fuses=0xDE
-atmega328-8.bootloader.extended_fuses=0xFD
+atmega328-8.bootloader.extended_fuses=0x05
 
 atmega328-8.build.mcu=atmega328p
 atmega328-8.build.f_cpu=8000000L


### PR DESCRIPTION
avrdude would read back the written 0xFD and see 0x05, for then to offer to write them again. Answering yes to this would result in an infinite loop. (using the cosa commandline script.)
ref. http://www.engbedded.com/fusecalc/ Any value above 0x07 will show a warning about this.