### PR TITLE
Root MIB special case no longer necessary for snmpwalk

### DIFF
--- a/cores/cosa/Cosa/INET/SNMP.cpp
+++ b/cores/cosa/Cosa/INET/SNMP.cpp
@@ -408,15 +408,6 @@ SNMP::request(PDU& pdu, uint32_t ms)
   int res = recv(pdu, ms);
   if (res < 0) return (res);
 
-  // Check for root getnext request
-  if ((pdu.type == PDU_GET_NEXT)
-      && (pdu.oid.length == 1)
-      && (pdu.oid.name[0] == 0)) {
-    const uint8_t* oid = MIB2_SYSTEM::OID;
-    memcpy_P(&pdu.oid, oid, pgm_read_byte(oid) + 1);
-    pdu.oid.name[pdu.oid.length++] = 0;
-  }
-
   // Match with MIB handlers
   if (!m_sys->is_request(pdu) && !m_mib->is_request(pdu))
     pdu.error_status = NO_SUCH_NAME;

--- a/cores/cosa/Cosa/INET/SNMP.cpp
+++ b/cores/cosa/Cosa/INET/SNMP.cpp
@@ -67,9 +67,7 @@ SNMP::MIB2_SYSTEM::is_request(PDU& pdu)
       pdu.value.encode_P(SNMP::SYNTAX_OCTETS, m_descr, strlen_P(m_descr));
       break;
     case sysObjectID:
-      pdu.value.encode_P(SNMP::SYNTAX_OID,
-			 (const char*) ARDUINO_MIB_OID + 1,
-			 pgm_read_byte(ARDUINO_MIB_OID));
+      pdu.value.encode_P(SNMP::SYNTAX_OID, (const char*) m_sysoid + 1, pgm_read_byte(m_sysoid));
       break;
     case sysUpTime:
       pdu.value.encode(SNMP::SYNTAX_TIME_TICKS, Watchdog::millis() / 1000L);

--- a/cores/cosa/Cosa/INET/SNMP.hh
+++ b/cores/cosa/Cosa/INET/SNMP.hh
@@ -171,11 +171,13 @@ public:
     MIB2_SYSTEM(const char* descr,
 		const char* contact,
 		const char* name,
-		const char* location) :
+		const char* location,
+        const uint8_t* sysoid=ARDUINO_MIB_OID) :
       m_descr(descr),
       m_contact(contact),
       m_name(name),
-      m_location(location)
+      m_location(location),
+      m_sysoid(sysoid)
     {
     }
 
@@ -203,6 +205,7 @@ public:
     const char* m_contact;
     const char* m_name;
     const char* m_location;
+    const uint8_t* m_sysoid;
     enum {
       sysDescr = 1,		//!< DisplayString(0..255), read-only, mandatory.
       sysObjectID = 2,		//!< OID, read-only, mandatory.


### PR DESCRIPTION
Doing a code walkthrough and realised this special case of doing a GET_NEXT with 0 OID was just no longer ever necessary.