### PR TITLE
Several makefile enhancements

### DIFF
--- a/build/Arduino-Makefile/bin/ard-wait-arduino
+++ b/build/Arduino-Makefile/bin/ard-wait-arduino
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# Wait for the inode number of a file to change.  This is used to detect a device
+# going away and then returning.  Arduino devices that have native USB, like Leonardo,
+# will go away temporarily after a reset or upload (for 15 seconds or more).
+
+from __future__ import print_function
+import os
+import sys
+import argparse
+from time import sleep
+
+parser = argparse.ArgumentParser(description='Wait for an Arduino')
+parser.add_argument('--inode', type=int, default=0, help="Old inode.")
+parser.add_argument('--timeout', type=int, default=30, help="Timeout before error.")
+parser.add_argument('--verbose', action='store_true', help="Watch what's going on on STDERR.")
+parser.add_argument('port', nargs=1, help='Serial device e.g. /dev/ttyACM0')
+args = parser.parse_args()
+
+if args.inode == 0:
+    if os.path.exists(args.port[0]):
+        # must assume current file is old one
+        args.inode = os.stat(args.port[0]).st_ino
+
+if os.path.exists(args.port[0]):
+    if os.stat(args.port[0]).st_ino == args.inode:
+        if args.verbose: print('Waiting for %s to go away' % args.port[0])
+        countdown = args.timeout
+        while 1:
+            if countdown == 0:
+                if args.verbose: print('%s didn\'t go away before timeout' % args.port[0])
+                sys.exit(1)
+            if not os.path.exists(args.port[0]) or os.stat(args.port[0]).st_ino != args.inode:
+                break;
+            if args.verbose:
+                for tick in range(0, countdown):
+                    print ('.', end='')
+                print ('')
+            countdown = countdown - 1
+            sleep(1)
+    else:
+        if args.verbose: print('%s has already changed' % args.port[0])
+        sys.exit(0)
+
+if args.verbose: print('Waiting for %s to appear' % args.port[0])
+countdown = args.timeout
+while 1:
+    if countdown == 0:
+        if args.verbose: print('%s didn\'t appear before timeout' % args.port[0])
+        sys.exit(1)
+    if os.path.exists(args.port[0]):
+        break;
+    if args.verbose:
+        for tick in range(0, countdown):
+            print ('.', end='')
+        print ('')
+    countdown = countdown - 1
+    sleep(1)


### PR DESCRIPTION
Makefile goal 'config' now always shows config regardless of ARDUINO_QUIET. Add optional COSA_OBJDIR environment variable. Add `ard-wait-arduino` script and enhance 'avanti' goal so that monitoring doesn't begin until the device reappears (for caterina only).

If we were creating from scratch we would avoid environment names like OBJDIR as that is potentially problematic to set in a global environment.  To maintain backward compatibility this keeps OBJDIR and introduces COSA_OBJDIR.