### PR TITLE
Allow IOStream output when no device is associated with stream

### DIFF
--- a/cores/cosa/Cosa/IOStream.cpp
+++ b/cores/cosa/Cosa/IOStream.cpp
@@ -45,7 +45,7 @@ IOStream::IOStream() :
 IOStream::Device*
 IOStream::set_device(Device* dev)
 {
-  if (dev == NULL) return (m_dev);
+  //  if (dev == NULL) return (m_dev);
   Device* previous = m_dev;
   m_dev = dev;
   return (previous);

--- a/cores/cosa/Cosa/IOStream.hh
+++ b/cores/cosa/Cosa/IOStream.hh
@@ -430,8 +430,10 @@ public:
    * @param[in] c character to print.
    */
   void print(char c)
+    __attribute__((always_inline))
   {
-    m_dev->putchar(c);
+    if (m_dev != NULL)
+      m_dev->putchar(c);
   }
 
   /**
@@ -439,8 +441,10 @@ public:
    * @param[in] s pointer to data memory string.
    */
   void print(const char* s)
+    __attribute__((always_inline))
   {
-    m_dev->puts(s);
+    if (m_dev != NULL)
+      m_dev->puts(s);
   }
 
   /**
@@ -449,16 +453,20 @@ public:
    * @param[in] s pointer to program memory string.
    */
   void print(str_P s)
+    __attribute__((always_inline))
   {
-    m_dev->puts(s);
+    if (m_dev != NULL)
+      m_dev->puts(s);
   }
 
   /**
    * Print end of line to stream.
    */
   void println()
+    __attribute__((always_inline))
   {
-    m_dev->puts(m_eols);
+    if (m_dev != NULL)
+      m_dev->puts(m_eols);
   }
 
   /**
@@ -493,8 +501,10 @@ public:
    * Flush contents of iostream to stream.
    */
   void flush()
+    __attribute__((always_inline))
   {
-    m_dev->flush();
+    if (m_dev != NULL)
+      m_dev->flush();
   }
 
   /**
@@ -820,7 +830,8 @@ clear(IOStream& outs)
 inline IOStream&
 flush(IOStream& outs)
 {
-  outs.m_dev->flush();
+  if (outs.m_dev != NULL)
+    outs.m_dev->flush();
   return (outs);
 }
 #endif


### PR DESCRIPTION
Fix IOStream so that output does not cause crash when no device is associated.

`Trace::end()` calls `set_device(NULL)` so it must be accepted as a new device.
All IOStream output methods now verify that `m_dev` is not NULL before dereferencing.