### PR TITLE
Keep USB alive after exit()

### DIFF
--- a/cores/cosa/Cosa/USB/Core.cpp
+++ b/cores/cosa/Cosa/USB/Core.cpp
@@ -511,7 +511,8 @@ SendDescriptor(Setup& setup)
   return (true);
 }
 
-ISR(USB_COM_vect)
+static void
+Handle_USB_COM(void)
 {
   SetEP(0);
   if (!ReceivedSetupInt()) return;
@@ -570,6 +571,19 @@ ISR(USB_COM_vect)
     ClearIN();
   else
     Stall();
+}
+
+ISR(USB_COM_vect)
+{
+  Handle_USB_COM();
+}
+
+// USB_Keepalive is called from exit implemented in main.cpp
+void
+USB_Keepalive(void)
+{
+  while (_usbConfiguration)
+    Handle_USB_COM();
 }
 
 void

--- a/cores/cosa/main.cpp
+++ b/cores/cosa/main.cpp
@@ -113,6 +113,29 @@ int main(void)
 }
 
 /**
+ * The exit function. This function may be overridden.
+ */
+void exit(int status) __attribute__((weak));
+void exit(int status)
+{
+  UNUSED(status);
+
+  cli();
+
+#if defined(USBCON)
+  extern void USB_Keepalive(void);
+  USB_Keepalive();  // never returns
+#endif
+
+  // Hang forever in sleep mode
+  while (1)
+    Power::sleep();
+
+  // Failsafe
+  while (1);
+}
+
+/**
  * Default delay function; busy-wait given number of milli-seconds.
  * @param[in] ms milli-seconds delay.
  */


### PR DESCRIPTION
USB must continue to handle events in order to detect a request to enter bootloader.

This implementation allows an application to override `exit()`. The default behavior mimics standard AVR GCC in that it 1) disables all interrupts and 2) goes into an infinite loop.  If USB is present the infinite loop will be looking for and processing USB events including those that enter the bootloader. If USB is not present the infinite loop will enter sleep mode.