### PR TITLE
Output pins must be initialized

### DIFF
--- a/cores/cosa/Cosa/Linkage.hh
+++ b/cores/cosa/Cosa/Linkage.hh
@@ -25,7 +25,7 @@
 #include "Cosa/Event.hh"
 
 /**
- * The Cosa collection handling class; double linked circulic list.
+ * The Cosa collection handling class; double linked circular list.
  *
  * @section Acknowledgements
  * These classes are inspired by the Simula-67 SIMSET Linkage classes.
@@ -70,11 +70,10 @@ public:
   void attach(Linkage* pred)
   {
     synchronized {
-
       // Check if it needs to be detached first
       if (pred->m_succ != pred) {
-	pred->m_succ->m_pred = pred->m_pred;
-	pred->m_pred->m_succ = pred->m_succ;
+        pred->m_succ->m_pred = pred->m_pred;
+        pred->m_pred->m_succ = pred->m_succ;
       }
 
       // Attach pred as the new predecessor

--- a/examples/Blink/CosaBlinkMinimal/CosaBlinkMinimal.ino
+++ b/examples/Blink/CosaBlinkMinimal/CosaBlinkMinimal.ino
@@ -20,7 +20,8 @@
  * written in Cosa using the Arduino built-in LED and minimal number of
  * lines of code. Uses the OutputPin static member function toggle to
  * turn on and off the built-in LED. And the default delay function
- * which is a busy-wait loop. No setup function is necessary.
+ * which is a busy-wait loop.
+ * The pin must be set up as an Output pin since the default is Input.
  *
  * @section Circuit
  * Uses built-in LED (D13/Arduino).
@@ -28,7 +29,13 @@
  * This file is part of the Arduino Che Cosa project.
  */
 
-#include "Cosa/OutputPin.hh"
+#include "Cosa/IOPin.hh"
+
+void setup ()
+{
+  // Pins default to Input - set Output
+  IOPin::set_mode(Board::LED,IOPin::OUTPUT_MODE);
+}
 
 void loop()
 {

--- a/examples/UML/CosaCapsules/CosaCapsules.ino
+++ b/examples/UML/CosaCapsules/CosaCapsules.ino
@@ -20,7 +20,7 @@
  * probed. The LED will blink when the Button is on otherwise the LED
  * is turned off. The probes will trace changes to the connector
  * value. The Clock and the Button are timed capsules. The clock has a
- * period of 1024 ms and the Button 64 ms. The Button will debound the
+ * period of 1024 ms and the Button 64 ms. The Button will debounce the
  * digital input pin. The LED has control dependency to the Clock tick
  * and a data dependency to the Button signal.
  *

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -33,7 +33,7 @@ Firmata.
 
 The primary programming paradigm is object-oriented and
 state-machine/event driven with proto-threads or multi-tasking. There
-is a large number of device drivers available for SPI, I2C (TWI) and
+are a large number of device drivers available for SPI, I2C (TWI) and
 1-Wire (OWI). A strict directory structure is used to organize the
 Cosa/driver source code. Sub-directories are used for each driver
 type. This allows a foundation for scaling and configuration.
@@ -62,14 +62,14 @@ The popular VirtualWire library has been refactored to the
 object-oriented style of Cosa (VWI) and extended with three additional
 codecs; Manchester, 4B5B and Bitstuffing. This allows basic ultra
 cheap wireless nodes with RF315/433 receiver and transmitter. For more
-advanced wireless connections there is also drivers for the Nordic
+advanced wireless connections there are also drivers for the Nordic
 Semiconductor NRF24L01+ chip, the TI CC1101 Low-Power Sub-1 GHz RF
 Transceiver, and RFM69.  
 
 The goal of this project is to provide an efficient programming
 platform for rapid prototyping of "Internet-of-things"-devices. There
 is an Ethernet/Socket with W5100 Ethernet controller device
-driver. This implementation allows streaming direct to the device
+driver. This implementation allows streaming directly to the device
 buffers. Cosa also implements a number of IP protocols; DNS, DHCP,
 NTP, HTTP, SNMP and MQTT. 
 


### PR DESCRIPTION
The default state of a pin is input. Something must be done to convert it to output. In "normal" usage, an object would be created and the constructor would handle the issue. However, this "minimal" sketch never creates the object. Therefore some setup is required. 