### PR TITLE
Fix USB performance after host serial disconnect

### DIFF
--- a/cores/cosa/Cosa/IOStream/Driver/CDC.cpp
+++ b/cores/cosa/Cosa/IOStream/Driver/CDC.cpp
@@ -118,6 +118,12 @@ CDC_Setup(Setup& setup)
       }
       return (true);
     }
+
+    if (CDC_SEND_BREAK == r) {
+      // lost serial connection; mark lineState as gone
+      _usbLineInfo.lineState = 0;
+      return (true);
+    }
   }
   return (false);
 }
@@ -163,10 +169,11 @@ CDC::empty(void)
 int
 CDC::write(const void* buf, size_t size)
 {
-  if ((_usbLineInfo.lineState > 0)
-      && (USB_Send(CDC_TX, buf, size) == (int) size))
-    return (size);
-  return (IOStream::EOF);
+  if ((_usbLineInfo.lineState & 0x01) &&
+      (USB_Send(CDC_TX, buf, size) != (int) size))
+    return (IOStream::EOF);
+
+  return (size);
 }
 
 #endif

--- a/cores/cosa/Cosa/USB/Core.h
+++ b/cores/cosa/Cosa/USB/Core.h
@@ -62,6 +62,7 @@
 #define CDC_SET_LINE_CODING			0x20
 #define CDC_GET_LINE_CODING			0x21
 #define CDC_SET_CONTROL_LINE_STATE		0x22
+#define CDC_SEND_BREAK				0x23
 
 #define MSC_RESET				0xFF
 #define MSC_GET_MAX_LUN				0xFE


### PR DESCRIPTION
When the host is monitoring and then stops monitoring, the Cosa code doing writes to the CDC device became slower. This change only attempts USB writes when the host serial port is active. Tested on OSX but hopefully same behavior on other platforms.

Fixes https://github.com/mikaelpatel/Cosa/issues/259