### PR TITLE
Improve Event handling

### DIFF
--- a/cores/cosa/Cosa/Event.cpp
+++ b/cores/cosa/Cosa/Event.cpp
@@ -38,3 +38,10 @@ Event::service(uint32_t ms)
   return (true);
 }
 
+bool
+Event::operator==(const Event &t)
+{
+  return (m_type == t.m_type &&
+          m_target == t.m_target &&
+          m_value == t.m_value);
+}

--- a/cores/cosa/Cosa/Event.hh
+++ b/cores/cosa/Cosa/Event.hh
@@ -205,6 +205,13 @@ public:
    */
   static bool service(uint32_t ms = 0L);
 
+  /**
+   * Compare events.
+   * @param[in] t event to compare to this.
+   * @return true(1) if event values match.
+   */
+  bool operator==(const Event &t);
+
 private:
   uint8_t m_type;		//!< Event type.
   Handler* m_target;		//!< Event target object (receiver).


### PR DESCRIPTION
Event queue is very short and can easily cause high-rate events to be lost. This change adds 1 byte to each queue slot to maintain a counter of the number of "push" events that were recorded for that slot (ie matching events). The next slot will be taken if a push would cause a counter overflow or it is a different event.

The main negative to this change is that any class used in a queue must implement the "==" operator. A little overhead is added to enqueue/dequeue.