### PR TITLE
Use W5100::Socket::write() progmem param in W5100::dev_write()

### DIFF
--- a/libraries/W5100/W5100.cpp
+++ b/libraries/W5100/W5100.cpp
@@ -145,21 +145,12 @@ W5100::Driver::dev_write(const void* buf, size_t len, bool progmem)
   uint16_t offset = m_tx_offset;
   if (offset + len > BUF_MAX) {
     uint16_t size = BUF_MAX - offset;
-    if (progmem) {
-      m_dev->write_P(m_tx_buf + offset, bp, size);
-      m_dev->write_P(m_tx_buf, bp + size, len - size);
-    }
-    else {
-      m_dev->write(m_tx_buf + offset, bp, size);
-      m_dev->write(m_tx_buf, bp + size, len - size);
-    }
+    m_dev->write(m_tx_buf + offset, bp, size, progmem);
+    m_dev->write(m_tx_buf, bp + size, len - size, progmem);
     m_tx_offset = len - size;
   }
   else {
-    if (progmem)
-      m_dev->write_P(m_tx_buf + offset, bp, len);
-    else
-      m_dev->write(m_tx_buf + offset, bp, len);
+    m_dev->write(m_tx_buf + offset, bp, len, progmem);
     m_tx_offset += len;
   }
 

--- a/libraries/W5100/W5100.hh
+++ b/libraries/W5100/W5100.hh
@@ -187,7 +187,7 @@ public:
     CR_SEND = 0x20,		//!< Transmit data according to TX_WR.
     CR_SEND_MAC = 0x21,		//!< UDP: Transmit data.
     CR_SEND_KEEP = 0x22,	//!< TCP: Check connection status.
-    CR_RECV = 0x40		//!< Receivering packet to RX_RD.
+    CR_RECV = 0x40		//!< Receiving packet to RX_RD.
   } __attribute__((packed));
 
   /**


### PR DESCRIPTION
Missed this in the last W5100 refactor pull request , seems to save 4 bytes of AVR program space in my build env - not a lot but every one counts when nearing capacity.