### PR TITLE
Created Memory.cpp and Memory.hh to fix linker errors

### DIFF
--- a/cores/cosa/Cosa/Memory.cpp
+++ b/cores/cosa/Cosa/Memory.cpp
@@ -1,5 +1,5 @@
 /**
- * @file Cosa/Memory.h
+ * @file Cosa/Memory.cpp
  * @version 1.0
  *
  * @section License
@@ -18,9 +18,11 @@
  * This file is part of the Arduino Che Cosa project.
  */
 
-#ifndef COSA_MEMORY_H
-#define COSA_MEMORY_H
-
 #include "Cosa/Memory.hh"
 
-#endif
+int free_memory()
+{
+  extern int __heap_start, *__brkval;
+  int v;
+  return ((int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval));
+}

--- a/cores/cosa/Cosa/Memory.hh
+++ b/cores/cosa/Cosa/Memory.hh
@@ -1,5 +1,5 @@
 /**
- * @file Cosa/Memory.h
+ * @file Cosa/Memory.hh
  * @version 1.0
  *
  * @section License
@@ -18,9 +18,13 @@
  * This file is part of the Arduino Che Cosa project.
  */
 
-#ifndef COSA_MEMORY_H
-#define COSA_MEMORY_H
+#ifndef COSA_MEMORY_HH
+#define COSA_MEMORY_HH
 
-#include "Cosa/Memory.hh"
+/**
+ * Return amount of free memory.
+ * @return number of bytes.
+ */
+int free_memory();
 
 #endif


### PR DESCRIPTION
With the function free_memory() defined in Cosa/Memory.h, including Cosa/Memory.h in more than one place results in a "multiple definition of `free_memory()'" error at link time. This looks like a fix, but I'm not sure it's the "right way" to fix it.