### PR TITLE
DHT : values are set to deflaut during sample period.

### DIFF
--- a/libraries/DHT/DHT.cpp
+++ b/libraries/DHT/DHT.cpp
@@ -70,7 +70,10 @@ DHT::on_interrupt(uint16_t arg)
   // Invalid sample reject sequence
  exception:
   m_ix = 0;
-
+  // Error humidity and temperature (out of range)
+  m_humidity = BAD_HUMIDITY_SAMPLE;
+  m_temperature = BAD_TEMPERATURE_SAMPLE;
+  
   // Sequence completed
  completed:
   m_state = COMPLETED;
@@ -82,9 +85,6 @@ DHT::on_interrupt(uint16_t arg)
 bool
 DHT::sample_request()
 {
-  // Error humidity and temperature (out of range)
-  m_humidity = BAD_HUMIDITY_SAMPLE;
-  m_temperature = BAD_TEMPERATURE_SAMPLE;
 
   // Issue a request; pull down for more than 18 ms
   set_mode(OUTPUT_MODE);


### PR DESCRIPTION
Don't invalidate previous sample, when requesting new sample.
Set default value of temperature and humidity only on error.