### PR TITLE
Enable data and eeprom size check and enforcement for everyone

### DIFF
--- a/build/Arduino-Makefile/Arduino.mk
+++ b/build/Arduino-Makefile/Arduino.mk
@@ -275,8 +275,8 @@
 #
 ########################################################################
 
-#PREVENT_DATA_SIZE=yes
-#PREVENT_EEPROM_SIZE=yes
+PREVENT_DATA_SIZE=yes
+PREVENT_EEPROM_SIZE=yes
 
 SIZE_HIGHLIGHT = "\\n"
 


### PR DESCRIPTION
This code has been optional since it was introduced. I have been using it since then with no problems.

This PR is phase 2, if you will, to enable this by default for all users.

If no problems occur in the next few months a future PR will remove all conditional code related to this feature.