### PR TITLE
Quick hack to make GCC-AVR toolchain only install work

### DIFF
--- a/build/Arduino-Makefile/Arduino.mk
+++ b/build/Arduino-Makefile/Arduino.mk
@@ -534,7 +534,7 @@ endif
 # Check if boards.txt should be generated from installed cores. Assume that
 # variant files have been added (symbol links).
 BOARDS_TXT_AVAILABLE := $(call dir_if_exists,$(BOARDS_TXT))
-ifndef $(BOARDS_TXT_AVAILABLE)
+ifndef BOARDS_TXT_AVAILABLE
   BOARDS_TXT_CAT := $(shell cat $(ARDUINO_SKETCHBOOK)/hardware/*/boards.txt > $(BOARDS_TXT))
 endif
 

--- a/build/Cosa.mk
+++ b/build/Cosa.mk
@@ -32,7 +32,7 @@ ARDMK_DIR = $(COSA_DIR)/build/Arduino-Makefile
 ARDUINO_CORE_PATH = $(COSA_DIR)/cores/cosa
 ARDUINO_VAR_PATH = $(COSA_DIR)/variants
 ARDUINO_LIB_PATH = $(COSA_DIR)/libraries
-BOARDS_TXT = $(COSA_DIR)/build/boards.txt
+BOARDS_TXT = $(COSA_DIR)/boards.txt
 
 MONITOR_CMD = $(COSA_DIR)/build/miniterm.py -q --lf
 


### PR DESCRIPTION
Back on this to hopefully have a bit of fun over xmas - updated to latest and the command line build seems to have got a bit broken, at least in my situation where I only  have the GCC-AVR toolchain installed on my dev platform (CentOS 6). This fixes my immediate problem but poking around it looks like the board handling 'has changed' / 'is changing' so the problem might have just been a passing glitch.

I could probably do a better job of fixing and testing this side of things if I knew what the end goal was - is there an _issue_ where this is documented?