### PR TITLE
First pass at some boards.txt handling where no Arduino IDE only GCC AVR

### DIFF
--- a/build/Arduino-Makefile/Arduino.mk
+++ b/build/Arduino-Makefile/Arduino.mk
@@ -531,13 +531,6 @@ else
 
 endif
 
-# Check if boards.txt should be generated from installed cores. Assume that
-# variant files have been added (symbol links).
-BOARDS_TXT_AVAILABLE := $(call dir_if_exists,$(BOARDS_TXT))
-ifndef BOARDS_TXT_AVAILABLE
-  BOARDS_TXT_CAT := $(shell cat $(ARDUINO_SKETCHBOOK)/hardware/*/boards.txt > $(BOARDS_TXT))
-endif
-
 ########################################################################
 # Miscellaneous
 

--- a/build/Cosa.mk
+++ b/build/Cosa.mk
@@ -32,7 +32,16 @@ ARDMK_DIR = $(COSA_DIR)/build/Arduino-Makefile
 ARDUINO_CORE_PATH = $(COSA_DIR)/cores/cosa
 ARDUINO_VAR_PATH = $(COSA_DIR)/variants
 ARDUINO_LIB_PATH = $(COSA_DIR)/libraries
-BOARDS_TXT = $(COSA_DIR)/build/boards.txt
+ifndef BOARDS_TXT
+  BOARDS_TXT = $(COSA_DIR)/build/boards.txt
+endif
+ifeq ("$(wildcard $(BOARDS_TXT))", "")
+  $(shell cat $(COSA_DIR)/boards/*.txt > $(BOARDS_TXT))
+  BOARDS_TXT_MORE := $(wildcard $(ARDUINO_SKETCHBOOK)/hardware/*/boards.txt)
+  ifdef BOARDS_TXT_MORE
+     $(shell cat $BOARDS_TXT_MORE >> $(BOARDS_TXT))
+  endif
+endif
 
 MONITOR_CMD = $(COSA_DIR)/build/miniterm.py -q --lf
 


### PR DESCRIPTION
Sorry Mikael, the makefile BOARDS_TXT_AVAILABLE fix you cherry picked from last pull request certainly helps but I'm still not having much joy using Cosa out of the box with a build environment with no Arduino IDE install and only GCC AVR present. I can fudge it to make it work no problem but I'd like to contribute and get this aspect of Cosa so that it works without much messing around.

This pull request is not really intended to be merged immediately, it is more for you comment and critique to see if you (or others) can spot anything I may be doing that can break other things. Plus it is far from ideal in that if any of boards txt files are updated these changes have no way of being automatically fixed in the generated boards.txt, which should be possible to get working within the context of a Makefile.

Moved the boards.txt into the Cosa.mk as it felt like the right place to do it given that Arduino.mk is a seperately maintained project... or do you view this as being forked and changed enough so it would be too difficult to get back on track with the upstream version?

A few other minor suggestions:

- What do you think of moving all command line build instructions from COSA_DIR/INSTALL.txt into COSA_DIR/build/INSTALL.txt leaving only clue pointer text in the root one? Not sure how this would relate to COSA_DIR/doc/02-install.md ..?

- None of install instructions really mention ARDUINO_DIR needs to be set to something for Arduino.mk - I set mine to 'whocares', which works, but it might help to automatically set it to something if not already set up in build/cosa or Cosa.mk

- Similar for ARDUINO_SKETCHBOOK but this needs to be set to something sensible, at least it needs to be directory that contains hardware/ and libraries/ as far as I have worked out so far.

- My gut tells me generated boards.txt really ought to go in COSA_DIR/obj/ rather than in build but maybe you have your reasons for where it is..?

Hope this all makes sense and is at least little bit helpful.
Cheers
/dan