### PR TITLE
Fixed boards.txt path in Cosa.mk

### DIFF
--- a/build/Cosa.mk
+++ b/build/Cosa.mk
@@ -32,7 +32,7 @@ ARDMK_DIR = $(COSA_DIR)/build/Arduino-Makefile
 ARDUINO_CORE_PATH = $(COSA_DIR)/cores/cosa
 ARDUINO_VAR_PATH = $(COSA_DIR)/variants
 ARDUINO_LIB_PATH = $(COSA_DIR)/libraries
-BOARDS_TXT = $(COSA_DIR)/build/boards.txt
+BOARDS_TXT = $(COSA_DIR)/boards.txt
 
 MONITOR_CMD = $(COSA_DIR)/build/miniterm.py -q --lf
 


### PR DESCRIPTION
I'm running Cosa with`gcc-avr` on MacOS and Ubuntu 16.04.

https://github.com/mikaelpatel/Cosa/blob/77616bc8a52123c9b697b1361fbb332da2f5703c/build/Cosa.mk#L35

But the actual path is `$COSA_DIR/boards.txt`. This results in no output from running `cosa boards` and an error when trying to build using `cosa [BOARD]` (`missing device or architecture after '-mmcu='`)

https://github.com/mikaelpatel/Cosa/pull/470 seems to be related?