### PR TITLE
[BUGFIX] - Broken SYNC TWI SLAVE

### DIFF
--- a/cores/cosa/Cosa/TWI.cpp
+++ b/cores/cosa/Cosa/TWI.cpp
@@ -157,11 +157,13 @@ TWI::isr_stop(State state, uint8_t type)
   if (UNLIKELY(state == TWI::ERROR_STATE)) m_count = -1;
   m_state = state;
 
-  // Check for asynchronous mode and call completion callback
-  if (m_dev->is_async() || m_status == SR_STOP) {
-    m_dev->on_completion(type, m_count);
+  // Call completion callback before setting to default states.
+  m_dev->on_completion(type, m_count);
+  m_busy = false;
+
+  // Set extra states to default for asynchronous mode.
+  if (m_dev->is_async()) {
     m_dev = NULL;
-    m_busy = false;
     TWCR = 0;
   }
 }


### PR DESCRIPTION
Modified this condition that was calling the completion callback and setting some variables for async and sync mode (in the same way). 

```if (m_dev->is_async() || m_status == SR_STOP)```

The issue was that when we weren't using async mode m_status would still be true and go in the conditional block. In the conditional block setting m_dev to NULL and TWCR to 0 breaks the sync mode (but those are there for asynchronous mode). 

So i took the common part:
>  m_dev->on_completion(type, m_count);

And moved it out of the conditional block (because it is needed for both sync and async modes, so it should always happen).

Then we just set m_busy to false (setting this to false has no effect on sync mode). 

But as setting m_dev(NULL) and TWCR(0) breaks sync, so we only do them if it is async (i.e. is_async()).

Some asynchronous  mode testing wouldn't hurt (please let us know if you have any rough async mode TWI examples).