### PR TITLE
Workaround for false-positive syntax error reported by Intellisense in Visual Studio

### DIFF
--- a/cores/cosa/Cosa/Types.h
+++ b/cores/cosa/Cosa/Types.h
@@ -191,13 +191,22 @@ typedef const PROGMEM class prog_str* str_P;
  * @param[in] s string literal (at compile time).
  * @return string literal in program memory.
  */
-#define STR_P(s)							\
-  (__extension__(							\
-    {									\
-      static const char __c[] __PROGMEM = (s);				\
-      (str_P) &__c[0];							\
-    }									\
-  ))
+#ifndef __INTELLISENSE__
+# define STR_P(s)							\
+   (__extension__(							\
+     {									\
+       static const char __c[] __PROGMEM = (s);				\
+       (str_P) &__c[0];							\
+     }									\
+   ))
+#else /* __INTELLISENSE__ */
+/*
+ * Provide plain string to Visual Studio's Intellisense, because
+ * it doesn't support statement expressions. This macro is used
+ * for syntax checking only and doesn't affect build.
+ */
+# define STR_P(s) (s)
+#endif /* __INTELLISENSE__ */
 #undef PSTR
 #define PSTR(s) STR_P(s)
 #define __PSTR(s) STR_P(s)
@@ -391,11 +400,6 @@ inline uint8_t lock(condvar_t &cond)
 struct iovec_t {
   void* buf;			//!< Buffer pointer.
   size_t size;			//!< Size of buffer in bytes.
-  iovec_t(void* buf = NULL, size_t size = 0)
-  {
-    this->buf = buf;
-    this->size = size;
-  }
 };
 
 /**


### PR DESCRIPTION
When I edit programs for _Cosa_ in _Visual Studio_, _Intellisense_ (syntax-checker feature in _Visual Studio_) reports an **_"expected an expression"_** error on all instances of _PSTR()_ macro and highlights them with red squiggle. It's because _Intellisense_ doesn't support statement expressions, used in _PSTR()_ definition. Since _GCC_ is used for compilation (which supports statement expressions just fine), these reported errors are false-positives (ie. error is reported for correct code). It's really annoying to see these red squiggles everywhere in code, since it distracts from real syntax errors.

This PR workarounds this by providing different (plain-string) definition of _PSTR()_ to the _Intellisense_, while keeping definition used for build untouched.
